### PR TITLE
Fix check for MSWin32 in shellwords

### DIFF
--- a/lib/FFI/Build/Platform.pm
+++ b/lib/FFI/Build/Platform.pm
@@ -300,7 +300,7 @@ sub shellwords
 {
   my $self = _self(shift);
 
-  my $win = !!$self->osname eq 'MSWin32';
+  my $win = !!($self->osname eq 'MSWin32');
 
   grep { defined $_ } map {
     ref $_


### PR DESCRIPTION
This was always evaluating to false, causing backslash path separators
to never be escaped.

--

In Strawberry, Config.pm's `cc` is `'gcc'`, but I tried installing on an ActiveState Perl with their MinGW PPM installed, and its `cc` is `'C:\Perl\site\bin\gcc.exe'` - found failures in config.log looking for `'C:Perlsitebingcc.exe'` and tracked this issue down.  