### PR TITLE
global sub oopsie

### DIFF
--- a/lib/FFI/Build.pm
+++ b/lib/FFI/Build.pm
@@ -309,7 +309,7 @@ sub _file_classes
     # also anything already loaded, that might not be in the
     # @INC path (for testing ususally)
     push @file_classes,
-      map { my $f = $_; $f =~ s/::$//; "FFI::Build::File::$f" }
+      map { my $f = $_; $f =~ s/::$//g; "FFI::Build::File::$f" }
       grep !/Base::/,
       grep /::$/,
       keys %{FFI::Build::File::};

--- a/lib/FFI/Platypus/Bundle.pm
+++ b/lib/FFI/Platypus/Bundle.pm
@@ -361,7 +361,7 @@ sub _bundle
     my($output, $error) = Capture::Tiny::capture_merged(sub {
       $lib = eval {
         my $dist_name = $package;
-        $dist_name =~ s/::/-/;
+        $dist_name =~ s/::/-/g;
         my $fbmm = FFI::Build::MM->new( save => 0 );
         $fbmm->mm_args( DISTNAME => $dist_name );
         my $build = $fbmm->load_build('ffi', undef, 'ffi/_build');


### PR DESCRIPTION
This fixes a bug where only the first :: is converted to a - for the .so name.  This is probably critical for windows, although linux at least doesn't seem to care.  For completeness we should support the old format for read, but only create the new format going forward.  Thus this PR is incomplete and in the draft state.