### PR TITLE
fix double colon filename leakage

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Fix bug where bundled .so name could incorrectly get double colons (::)
+    in the name in development mode only.  This is probably only a problem
+    on Windows. (gh#284)
 
 1.32      2020-09-21 04:25:13 -0600
   - Fix unsupported Perl tests.

--- a/lib/FFI/Platypus/Bundle.pm
+++ b/lib/FFI/Platypus/Bundle.pm
@@ -361,7 +361,7 @@ sub _bundle
     my($output, $error) = Capture::Tiny::capture_merged(sub {
       $lib = eval {
         my $dist_name = $package;
-        $dist_name =~ s/::/-/;
+        $dist_name =~ s/::/-/g;
         my $fbmm = FFI::Build::MM->new( save => 0 );
         $fbmm->mm_args( DISTNAME => $dist_name );
         my $build = $fbmm->load_build('ffi', undef, 'ffi/_build');


### PR DESCRIPTION
See also #281, which didn't quite get it right.

At first this looked like this could be complicated because I though old installed FFI extensions could be affected ad we'd have to support both name formats, but on closer inspection the bug only exists when computing the development filename, so we can just fix it without having to worry about backward compatibility.  Also it looks like this is only an issue with Windows (where filenames with `::` would be bad) when the FFI extension doesn't use a `.fbx` file.