### PR TITLE
Fix the function signature for alignment

### DIFF
--- a/lib/FFI/Platypus/Record/Meta.pm
+++ b/lib/FFI/Platypus/Record/Meta.pm
@@ -69,7 +69,7 @@ the public interface to Platypus records.
 
   $ffi->attach( ffi_type         => ['meta_t'] => 'ffi_type'   );
   $ffi->attach( size             => ['meta_t'] => 'size_t'     );
-  $ffi->attach( alignment        => ['meta_t'] => 'uint'       );
+  $ffi->attach( alignment        => ['meta_t'] => 'ushort'     );
   $ffi->attach( element_pointers => ['meta_t'] => 'ffi_type[]' );
 
   $ffi->attach( DESTROY          => ['meta_t'] => 'void'       );


### PR DESCRIPTION
There was a test failure related to this function reported as #287. Waiting to hear back if this resolves it, but we should make this
change anyway since it is definitely incorrect.