### PR TITLE
Add wide string type plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ jobs:
     - env: CIP_TAG=5.32
     - env: CIP_TAG=5.32-buster-arm64v8
       arch: arm64
-    - env: CIP_TAG=5.30-debug
-    - env: CIP_TAG=5.30-debug32
+    - env: CIP_TAG=5.32-debug
+    - env: CIP_TAG=5.32-debug32
     - env: CIP_TAG=5.32-buster32
     - env: CIP_TAG=5.32 CIP_ENV=FFI_PLATYPUS_MEMORY_STRDUP_IMPL=ffi
     - env: CIP_TAG=5.32-threads

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - cip before-install
 
 install:
+  - cip login
   - cip diag
   - cip install
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Favor the Microsoft strdup over the bundled copy if found as _strdup
+    which is what it is called now.
 
 1.34      2020-10-23 09:04:46 -0600
   - Fixed bug in in record meta object which expressed itself on at least

--- a/Changes
+++ b/Changes
@@ -2,7 +2,8 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
   - Favor the Microsoft strdup over the bundled copy if found as _strdup
-    which is what it is called now.
+    which is what it is called now (gh#299).
+  - Added FFI::Platypus::Type::WideString type plugin (IKEGAMI++ gh#291, gh#292, gh#299)
 
 1.34      2020-10-23 09:04:46 -0600
   - Fixed bug in in record meta object which expressed itself on at least

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -60,6 +60,7 @@ my %WriteMakefileArgs = (
     "lib/FFI/Platypus/Type/PointerSizeBuffer.pm" => "\$(INST_LIB)/FFI/Platypus/Type/PointerSizeBuffer.pm",
     "lib/FFI/Platypus/Type/StringArray.pm"       => "\$(INST_LIB)/FFI/Platypus/Type/StringArray.pm",
     "lib/FFI/Platypus/Type/StringPointer.pm"     => "\$(INST_LIB)/FFI/Platypus/Type/StringPointer.pm",
+    "lib/FFI/Platypus/Type/WideString.pm"        => "\$(INST_LIB)/FFI/Platypus/Type/WideString.pm",
     "lib/FFI/Platypus/TypeParser.pm"             => "\$(INST_LIB)/FFI/Platypus/TypeParser.pm",
     "lib/FFI/Platypus/TypeParser/Version0.pm"    => "\$(INST_LIB)/FFI/Platypus/TypeParser/Version0.pm",
     "lib/FFI/Platypus/TypeParser/Version1.pm"    => "\$(INST_LIB)/FFI/Platypus/TypeParser/Version1.pm",

--- a/README.md
+++ b/README.md
@@ -1440,6 +1440,25 @@ wrapper function will be returned back to the original caller.
 
 ## The Win32 API
 
+```perl
+use utf8;
+use FFI::Platypus;
+
+my $ffi = FFI::Platypus->new(
+  api  => 1,
+  lib  => [undef],
+);
+
+# see FFI::Platypus::Lang::Win32
+$ffi->lang('Win32');
+
+# Send a Unicode string to the Windows API MessageBoxW function.
+use constant MB_OK                   => 0x00000000;
+use constant MB_DEFAULT_DESKTOP_ONLY => 0x00020000;
+$ffi->attach( [MessageBoxW => 'MessageBox'] => [ 'HWND', 'LPCWSTR', 'LPCWSTR', 'UINT'] => 'int' );
+MessageBox(undef, "I ❤️ Platypus", "Confession", MB_OK|MB_DEFAULT_DESKTOP_ONLY);
+```
+
 **Discussion**: The API used by Microsoft Windows present some unique
 challenges.  On 32 bit systems a different ABI is used than what is
 used by the standard C library.  It also provides a rats nest of

--- a/README.md
+++ b/README.md
@@ -1961,6 +1961,8 @@ Meredith (merrilymeredith, MHOWARD)
 
 Diab Jerius (DJERIUS)
 
+Eric Brine (IKEGAMI)
+
 # COPYRIGHT AND LICENSE
 
 This software is copyright (c) 2015,2016,2017,2018,2019,2020 by Graham Ollis.

--- a/README.md
+++ b/README.md
@@ -1899,6 +1899,10 @@ the development package for `libffi` as prereqs for this module.
 
     Documentation and tools for using Platypus with the Assembly
 
+- [FFI::Platypus::Lang::Win32](https://metacpan.org/pod/FFI::Platypus::Lang::Win32)
+
+    Documentation and tools for using Platypus with the Win32 API.
+
 - [Convert::Binary::C](https://metacpan.org/pod/Convert::Binary::C)
 
     A great interface for decoding C data structures, including `struct`s,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Write Perl bindings to non-Perl libraries with FFI. No XS required.
 # SYNOPSIS
 
 ```perl
-use FFI::Platypus;
+use FFI::Platypus 1.00;
 
 # for all new code you should use api => 1
 my $ffi = FFI::Platypus->new( api => 1 );

--- a/README.md
+++ b/README.md
@@ -1032,8 +1032,13 @@ $ffi->attach(strerror => ['int'] => 'string');
 puts(strerror(2));
 ```
 
-**Discussion**: Strings are not a native type to `libffi` but the are
-handled seamlessly by Platypus.
+**Discussion**: ASCII and UTF-8 Strings are not a native type to `libffi`
+but the are handled seamlessly by Platypus.  If you need to talk to an
+API that uses so called "wide" strings (APIs which use `const wchar_t*`
+or `wchar_t*`), then you will want to use the wide string type plugin
+[FFI::Platypus::Type::WideString](https://metacpan.org/pod/FFI::Platypus::Type::WideString).  APIs which use other arbitrary
+encodings can be accessed by converting your Perl strings manually with
+the [Encode](https://metacpan.org/pod/Encode) module.
 
 ## Attach function from pointer
 
@@ -1432,6 +1437,18 @@ wrapper will be a code reference to the C function.  The Perl arguments
 will come in after that.  This allows you to modify / convert the
 arguments to conform to the C API.  What ever value you return from the
 wrapper function will be returned back to the original caller.
+
+## The Win32 API
+
+**Discussion**: The API used by Microsoft Windows present some uniq
+challenges.  On 32 bit systems a different ABI is used than what is
+used by the standard C library.  It also provides a rats nest of
+type aliases.  Finally if you want to talk Unicode to any of the
+Windows API you will need to use `UTF-16LE` instead of `utf-8`
+which is native to Perl.  (The Win32 API referrs to these as
+`LPWSTR` and `LPCWSTR` types).  As much as possible the Win32
+"language" plugin attempts to handle this transparently.  For more
+details see [FFI::Platypus::Lang::Win32](https://metacpan.org/pod/FFI::Platypus::Lang::Win32).
 
 ## bundle your own code
 

--- a/README.md
+++ b/README.md
@@ -1903,6 +1903,12 @@ the development package for `libffi` as prereqs for this module.
 
     Documentation and tools for using Platypus with the Win32 API.
 
+- [Wasm](https://metacpan.org/pod/Wasm) and [Wasm::Wasmtime](https://metacpan.org/pod/Wasm::Wasmtime)
+
+    Modules for writing WebAssembly bindings in Perl.  This allows you to call
+    functions written in any language supported by WebAssembly.  These modules
+    are also implemented using Platypus.
+
 - [Convert::Binary::C](https://metacpan.org/pod/Convert::Binary::C)
 
     A great interface for decoding C data structures, including `struct`s,

--- a/README.md
+++ b/README.md
@@ -1440,12 +1440,12 @@ wrapper function will be returned back to the original caller.
 
 ## The Win32 API
 
-**Discussion**: The API used by Microsoft Windows present some uniq
+**Discussion**: The API used by Microsoft Windows present some unique
 challenges.  On 32 bit systems a different ABI is used than what is
 used by the standard C library.  It also provides a rats nest of
 type aliases.  Finally if you want to talk Unicode to any of the
 Windows API you will need to use `UTF-16LE` instead of `utf-8`
-which is native to Perl.  (The Win32 API referrs to these as
+which is native to Perl.  (The Win32 API refers to these as
 `LPWSTR` and `LPCWSTR` types).  As much as possible the Win32
 "language" plugin attempts to handle this transparently.  For more
 details see [FFI::Platypus::Lang::Win32](https://metacpan.org/pod/FFI::Platypus::Lang::Win32).

--- a/author.yml
+++ b/author.yml
@@ -141,6 +141,7 @@ pod_spelling_system:
     - IKEGAMI
     - BMP
     - WebAssembly
+    - sensical
 
 pod_coverage:
   skip: 0

--- a/author.yml
+++ b/author.yml
@@ -138,6 +138,7 @@ pod_spelling_system:
     - thet
     - unitof
     - const
+    - IKEGAMI
 
 pod_coverage:
   skip: 0

--- a/author.yml
+++ b/author.yml
@@ -140,6 +140,7 @@ pod_spelling_system:
     - const
     - IKEGAMI
     - BMP
+    - WebAssembly
 
 pod_coverage:
   skip: 0

--- a/author.yml
+++ b/author.yml
@@ -137,6 +137,7 @@ pod_spelling_system:
     - kindof
     - thet
     - unitof
+    - const
 
 pod_coverage:
   skip: 0

--- a/author.yml
+++ b/author.yml
@@ -139,6 +139,7 @@ pod_spelling_system:
     - unitof
     - const
     - IKEGAMI
+    - BMP
 
 pod_coverage:
   skip: 0

--- a/dist.ini
+++ b/dist.ini
@@ -215,6 +215,7 @@ filename = include/ppport.h
 directory = examples
 
 [InsertExample]
+:version = 0.10
 remove_boiler = 1
 
 [Author::Plicease::Thanks]

--- a/dist.ini
+++ b/dist.ini
@@ -237,6 +237,7 @@ contributor = Mohammad S Anwar (MANWAR)
 contributor = Håkon Hægland (hakonhagland, HAKONH)
 contributor = Meredith (merrilymeredith, MHOWARD)
 contributor = Diab Jerius (DJERIUS)
+contributor = Eric Brine (IKEGAMI)
 
 [PruneFiles]
 match = /tmpbuild\.

--- a/examples/win32_messagebox.pl
+++ b/examples/win32_messagebox.pl
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use utf8;
+use FFI::Platypus;
+
+my $ffi = FFI::Platypus->new(
+  api  => 1,
+  lib  => [undef],
+);
+
+# see FFI::Platypus::Lang::Win32
+$ffi->lang('Win32');
+
+# Send a Unicode string to the Windows API MessageBoxW function. 
+use constant MB_OK                   => 0x00000000;
+use constant MB_DEFAULT_DESKTOP_ONLY => 0x00020000;
+$ffi->attach( [MessageBoxW => 'MessageBox'] => [ 'HWND', 'LPCWSTR', 'LPCWSTR', 'UINT'] => 'int' );
+MessageBox(undef, "I ❤️ Platypus", "Confession", MB_OK|MB_DEFAULT_DESKTOP_ONLY);

--- a/examples/win32_messagebox.pl
+++ b/examples/win32_messagebox.pl
@@ -11,7 +11,7 @@ my $ffi = FFI::Platypus->new(
 # see FFI::Platypus::Lang::Win32
 $ffi->lang('Win32');
 
-# Send a Unicode string to the Windows API MessageBoxW function. 
+# Send a Unicode string to the Windows API MessageBoxW function.
 use constant MB_OK                   => 0x00000000;
 use constant MB_DEFAULT_DESKTOP_ONLY => 0x00020000;
 $ffi->attach( [MessageBoxW => 'MessageBox'] => [ 'HWND', 'LPCWSTR', 'LPCWSTR', 'UINT'] => 'int' );

--- a/examples/win32_messagebox.pl
+++ b/examples/win32_messagebox.pl
@@ -16,3 +16,4 @@ use constant MB_OK                   => 0x00000000;
 use constant MB_DEFAULT_DESKTOP_ONLY => 0x00020000;
 $ffi->attach( [MessageBoxW => 'MessageBox'] => [ 'HWND', 'LPCWSTR', 'LPCWSTR', 'UINT'] => 'int' );
 MessageBox(undef, "I ❤️ Platypus", "Confession", MB_OK|MB_DEFAULT_DESKTOP_ONLY);
+

--- a/lib/FFI/Build.pm
+++ b/lib/FFI/Build.pm
@@ -25,7 +25,7 @@ use File::Path ();
 
 =head1 SYNOPSIS
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  use FFI::Build;
  
  my $build = FFI::Build->new(

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -29,7 +29,7 @@ use FFI::Platypus::Type;
 
 =head1 SYNOPSIS
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  
  # for all new code you should use api => 1
  my $ffi = FFI::Platypus->new( api => 1 );

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -1927,6 +1927,12 @@ Documentation and tools for using Platypus with the Assembly
 
 Documentation and tools for using Platypus with the Win32 API.
 
+=item L<Wasm> and L<Wasm::Wasmtime>
+
+Modules for writing WebAssembly bindings in Perl.  This allows you to call
+functions written in any language supported by WebAssembly.  These modules
+are also implemented using Platypus.
+
 =item L<Convert::Binary::C>
 
 A great interface for decoding C data structures, including C<struct>s,

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -1401,8 +1401,13 @@ use C<undef> as the library to find them.
 
 # EXAMPLE: examples/string.pl
 
-B<Discussion>: Strings are not a native type to C<libffi> but the are
-handled seamlessly by Platypus.
+B<Discussion>: ASCII and UTF-8 Strings are not a native type to C<libffi>
+but the are handled seamlessly by Platypus.  If you need to talk to an
+API that uses so called "wide" strings (APIs which use C<const wchar_t*>
+or C<wchar_t*>), then you will want to use the wide string type plugin
+L<FFI::Platypus::Type::WideString>.  APIs which use other arbitrary
+encodings can be accessed by converting your Perl strings manually with
+the L<Encode> module.
 
 =head2 Attach function from pointer
 
@@ -1518,6 +1523,20 @@ wrapper will be a code reference to the C function.  The Perl arguments
 will come in after that.  This allows you to modify / convert the
 arguments to conform to the C API.  What ever value you return from the
 wrapper function will be returned back to the original caller.
+
+=head2 The Win32 API
+
+# EXAMPLE: examples/win32_messagebox.pl
+
+B<Discussion>: The API used by Microsoft Windows present some uniq
+challenges.  On 32 bit systems a different ABI is used than what is
+used by the standard C library.  It also provides a rats nest of
+type aliases.  Finally if you want to talk Unicode to any of the
+Windows API you will need to use C<UTF-16LE> instead of C<utf-8>
+which is native to Perl.  (The Win32 API referrs to these as
+C<LPWSTR> and C<LPCWSTR> types).  As much as possible the Win32
+"language" plugin attempts to handle this transparently.  For more
+details see L<FFI::Platypus::Lang::Win32>.
 
 =head2 bundle your own code
 

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -1923,6 +1923,10 @@ language
 
 Documentation and tools for using Platypus with the Assembly
 
+=item L<FFI::Platypus::Lang::Win32>
+
+Documentation and tools for using Platypus with the Win32 API.
+
 =item L<Convert::Binary::C>
 
 A great interface for decoding C data structures, including C<struct>s,

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -1528,12 +1528,12 @@ wrapper function will be returned back to the original caller.
 
 # EXAMPLE: examples/win32_messagebox.pl
 
-B<Discussion>: The API used by Microsoft Windows present some uniq
+B<Discussion>: The API used by Microsoft Windows present some unique
 challenges.  On 32 bit systems a different ABI is used than what is
 used by the standard C library.  It also provides a rats nest of
 type aliases.  Finally if you want to talk Unicode to any of the
 Windows API you will need to use C<UTF-16LE> instead of C<utf-8>
-which is native to Perl.  (The Win32 API referrs to these as
+which is native to Perl.  (The Win32 API refers to these as
 C<LPWSTR> and C<LPCWSTR> types).  As much as possible the Win32
 "language" plugin attempts to handle this transparently.  For more
 details see L<FFI::Platypus::Lang::Win32>.

--- a/lib/FFI/Platypus/Bundle.pm
+++ b/lib/FFI/Platypus/Bundle.pm
@@ -129,7 +129,7 @@ dist is named C<Foo-Bar> but your specific class is named C<Foo::Bar::Baz>, you'
 want something like this:
 
  package Foo::Bar::Baz;
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->bundle('Foo::Bar');
  ...

--- a/lib/FFI/Platypus/Closure.pm
+++ b/lib/FFI/Platypus/Closure.pm
@@ -23,7 +23,7 @@ create closure with OO interface
 
 create closure from Platypus object
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
  my $closure = $ffi->closure(sub { print "hello world\n" });
 

--- a/lib/FFI/Platypus/Constant.pm
+++ b/lib/FFI/Platypus/Constant.pm
@@ -28,10 +28,10 @@ C<lib/Foo.pm>:
  
  use strict;
  use warnings;
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  use base qw( Exporter );
  
- my $ffi = FFI::Platypus->new;
+ my $ffi = FFI::Platypus->new( api => 1 );
  # sets constatns Foo::FOO and ABC::DEF from C
  $ffi->bundle;
  

--- a/lib/FFI/Platypus/DL.pm
+++ b/lib/FFI/Platypus/DL.pm
@@ -14,7 +14,7 @@ push @EXPORT, grep /RTLD_/, keys %FFI::Platypus::DL::;
 
 =head1 SYNOPSIS
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  use FFI::Platypus::DL;
  
  my $handle = dlopen("./libfoo.so", RTLD_PLATYPUS_DEFAULT);

--- a/lib/FFI/Platypus/Function.pm
+++ b/lib/FFI/Platypus/Function.pm
@@ -10,7 +10,7 @@ use FFI::Platypus;
 
 =head1 SYNOPSIS
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  
  # call directly
  my $ffi = FFI::Platypus->new( api => 1 );

--- a/lib/FFI/Platypus/Lang.pm
+++ b/lib/FFI/Platypus/Lang.pm
@@ -25,7 +25,41 @@ This package itself doesn't do anything, it serves only as documentation.
 
 =item L<FFI::Platypus>
 
+Platypus itself.
+
+=item L<FFI::Platypus::Lang::ASM>
+
+This language plugin provides no type aliases, and is intended
+for use with assembly language or for when no other language
+plugin is appropriate.
+
 =item L<FFI::Platypus::Lang::C>
+
+Language plugin for the C programming language.
+
+=item L<FFI::Platypus::Lang::Fortran>
+
+Non-core language plugin for the Fortran programming language.
+
+=item L<FFI::Platypus::Lang::CPP>
+
+Non-core language plugin for the C++ programming language.
+
+=item L<FFI::Platypus::Lang::Go>
+
+Non-core language plugin for the Go programming language.
+
+=item L<FFI::Platypus::Lang::Pascal>
+
+Non-core language plugin for the Pascal programming language.
+
+=item L<FFI::Platypus::Lang::Rust>
+
+Non-core language plugin for the Rust programming language.
+
+=item L<FFI::Platypus::Lang::Win32>
+
+Language plugin for use with the Win32 API.
 
 =back
 

--- a/lib/FFI/Platypus/Lang/ASM.pm
+++ b/lib/FFI/Platypus/Lang/ASM.pm
@@ -9,7 +9,7 @@ use 5.008004;
 
 =head1 SYNOPSIS
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->lang('ASM');
 

--- a/lib/FFI/Platypus/Lang/ASM.pm
+++ b/lib/FFI/Platypus/Lang/ASM.pm
@@ -51,6 +51,10 @@ sub native_type_map
 
 The Core Platypus documentation.
 
+=item L<FFI::Platypus::Lang>
+
+Includes a list of other language plugins for Platypus.
+
 =back
 
 =cut

--- a/lib/FFI/Platypus/Lang/C.pm
+++ b/lib/FFI/Platypus/Lang/C.pm
@@ -9,7 +9,7 @@ use 5.008004;
 
 =head1 SYNOPSIS
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->lang('C'); # the default
 

--- a/lib/FFI/Platypus/Lang/C.pm
+++ b/lib/FFI/Platypus/Lang/C.pm
@@ -48,6 +48,10 @@ sub native_type_map
 
 The Core Platypus documentation.
 
+=item L<FFI::Platypus::Lang>
+
+Includes a list of other language plugins for Platypus.
+
 =back
 
 =cut

--- a/lib/FFI/Platypus/Lang/Win32.pm
+++ b/lib/FFI/Platypus/Lang/Win32.pm
@@ -11,7 +11,7 @@ use Config;
 =head1 SYNOPSIS
 
  use utf8;
- use FFI::Platypus 1.00;
+ use FFI::Platypus 1.35;
  
  my $ffi = FFI::Platypus->new(
    api  => 1,
@@ -21,14 +21,20 @@ use Config;
  # load this plugin
  $ffi->lang('Win32');
  
+ # Pass two double word integer values to the Windows API Beep function.
+ $ffi->attach( Beep => ['DWORD','DWORD'] => 'BOOL');
+ Beep(262, 300);
+ 
+ # Send a Unicode string to the Windows API MessageBoxW function.
  use constant MB_OK                   => 0x00000000;
  use constant MB_DEFAULT_DESKTOP_ONLY => 0x00020000;
  $ffi->attach( [MessageBoxW => 'MessageBox'] => [ 'HWND', 'LPCWSTR', 'LPCWSTR', 'UINT'] => 'int' );
  MessageBox(undef, "I ❤️ Platypus", "Confession", MB_OK|MB_DEFAULT_DESKTOP_ONLY);
  
+ # Get a Unicode string from the Windows API GetCurrentDirectoryW function.
  $ffi->attach( [GetCurrentDirectoryW => 'GetCurrentDirectory'] => ['DWORD', 'LPWSTR'] => 'DWORD');
  my $buf_size = GetCurrentDirectory(0,undef);
- my $dir = "\0" x ($buf_size*2);
+ my $dir = "\0\0" x $buf_size;
  GetCurrentDirectory($buf_size, \$dir) or die $^E;
  print "$dir\n";
 
@@ -42,11 +48,100 @@ current environment with this one-liner:
 
  perl -MFFI::Platypus::Lang::Win32 -E "say for sort keys %{ FFI::Platypus::Lang::Win32->native_type_map }"
 
-You also get C<LPCWSTR> and C<LPWSTR> "wide" string types which are
-implemented using L<FFI::Platypus::Type::WideString>.  For full details,
-please see the documentation for that module, and note that C<LPCWSTR>
-is a wide string in the read-only string mode and C<LPWSTR> is a wide
-string in the read-write buffer mode.
+This plugin will also set the correct ABI for use with Win32 API
+functions.  (On 32 bit systems a different ABI is used for Win32 API
+than what is used by the C library, on 32 bit systems the same ABI
+is used).  Most of the time this exactly what you want, but if you
+need to use functions that are using the standard C calling convention,
+but need the Win32 types, you can do that by setting the ABI back
+immediately after loading the language plugin:
+
+ $ffi->lang('Win32');
+ $ffi->abi('default_abi');
+
+Most of the types should be pretty self-explanatory or at least provided
+in the Microsoft documentation on the internet, but the use of Unicode
+strings probably requires some more detail:
+
+[version 1.35]
+
+This plugin also provides C<LPCWSTR> and C<LPWSTR> "wide" string types
+which are implemented using L<FFI::Platypus::Type::WideString>.  For
+full details, please see the documentation for that module, and note
+that C<LPCWSTR> is a wide string in the read-only string mode and
+C<LPWSTR> is a wide string in the read-write buffer mode.
+
+The C<LPCWSTR> is handled fairly transparently by the plugin, but for
+when using read-write buffers (C<LPWSTR>) with the Win32 API you typically
+need to allocate a buffer string of the right size.  These examples will
+use C<GetCurrentDirectoryW> attached as C<GetCurrentDirectory>
+as in the synopsis above.  These are illustrative only, you would normally
+want to use the L<Cwd> module to get the current working directory.
+
+=over 4
+
+=item default buffer size 2048
+
+The simplest way is to fallback on the rather arbitrary default buffer size of 2048.
+
+ my $dir;
+ GetCurrentDirectory(1024, \$dir);
+ print "I am in the directory: $dir\n";
+
+B<Discussion>: This only works if you know the API that you are using will not ever use
+more than 2048 bytes.  The author believes this to be the case for C<GetCurrentDirectoryW>
+since directory paths in windows have a maximum of 260 characters.  If every character was
+outside the Basic Multilingual Plane (BMP) they would take up exactly 4 characters each.
+(This is probably not ever the case since the disk volume at least will be a latin letter).
+Taking account of the C<NULL> termination you would need 260 * 4 + 2 bytes or 1048 bytes.
+
+We pass in a reference to our scalar so that the Win32 API can write into it.
+
+We are passing in half the number of bytes as the first argument because the API explects
+the number of C<WCHAR> (or C<wchar_t>), not the number of bytes or the technically the
+number of charactrs since characters can take up either 2 or 4 bytes in UTF-16.
+
+=item allocate your buffer to your own size.
+
+If possible it is of course always best to allocate exactly the size of buffer that
+you need.
+
+ my $size = GetCurrentDirectory(0, undef);
+ my $dir = "\0\0" x $size;
+ GetCurrentDirectory($size, \$dir);
+ print "I am in the directory: $dir\n";
+
+B<Discussion>: In this case the API provides a way of getting the exact size of buffer
+that you need.  We allocate this in Perl by creating a string of C<NULLs> of the right
+length.  The Perl string C<"\0"> is exactly on byte, so we double that before using the
+C<x> operator to multiple that by the size returned by the API.
+
+Now, somewhat unexpectedly what is returned is not the same buffer, but a new string
+in new UTF-8 encoded Perl string.  This is what you want most of the time.
+
+=item initialize your read-write buffer
+
+Some APIs might be modifying an existing string rather than just writing an entirely
+new one.  In  that case you still want to allocate a buffer, but you want to initialize
+it with a value.  You can do this by passing an array reference instead of a scalar
+reference.  The firs element of the array is the buffer, and the second is the initialization.
+
+ my $dir;
+ GetCurrentDirectory($size, [ \$dir, "I ❤ Perl + Platypus" ]);
+
+B<Discussion>: Note that this particular API ignores the string passed in and writes
+over it, but this demonstrates how you would initalize a buffer string.  Once again,
+if C<$dir> is not initialized (is C<undef>), then a buffer of the default size of 2048
+bytes will be created internally.  You can also allocate a specific number of bytes
+as in the previous example.
+
+=item allocate memory using C<malloc> etc.
+
+You can also allocate memory using C<malloc> (see L<FFI::Platypus::Memory>) and encode
+your string using L<Encode> and copy it using C<wcscpy>.  This may be appropriate in
+some cases, but it is beyond the scope of this document.
+
+=back
 
 =head1 METHODS
 
@@ -262,6 +357,16 @@ sub load_custom_types
 }
 
 1;
+
+=head1 CAVEATS
+
+The Win32 API isn't a different computer language in the same sense that the
+other language plugins (those for Fortran or Rust for example).  But implementing
+these types as a language plugin is the most convenient way to do it.
+
+Prior to version 1.35, this plugin didn't provide an implementation for
+C<LPWSTR> or C<LPCWSTR>, so in the likely event that you need those types make
+sure you also require at least that version of Platypus.
 
 =head1 SEE ALSO
 

--- a/lib/FFI/Platypus/Lang/Win32.pm
+++ b/lib/FFI/Platypus/Lang/Win32.pm
@@ -92,14 +92,14 @@ B<Discussion>: This only works if you know the API that you are using will not e
 more than 2048 bytes.  The author believes this to be the case for C<GetCurrentDirectoryW>
 since directory paths in windows have a maximum of 260 characters.  If every character was
 outside the Basic Multilingual Plane (BMP) they would take up exactly 4 characters each.
-(This is probably not ever the case since the disk volume at least will be a latin letter).
+(This is probably not ever the case since the disk volume at least will be a Latin letter).
 Taking account of the C<NULL> termination you would need 260 * 4 + 2 bytes or 1048 bytes.
 
 We pass in a reference to our scalar so that the Win32 API can write into it.
 
-We are passing in half the number of bytes as the first argument because the API explects
+We are passing in half the number of bytes as the first argument because the API expects
 the number of C<WCHAR> (or C<wchar_t>), not the number of bytes or the technically the
-number of charactrs since characters can take up either 2 or 4 bytes in UTF-16.
+number of characters since characters can take up either 2 or 4 bytes in UTF-16.
 
 =item allocate your buffer to your own size.
 
@@ -130,7 +130,7 @@ reference.  The firs element of the array is the buffer, and the second is the i
  GetCurrentDirectory($size, [ \$dir, "I ❤ Perl + Platypus" ]);
 
 B<Discussion>: Note that this particular API ignores the string passed in and writes
-over it, but this demonstrates how you would initalize a buffer string.  Once again,
+over it, but this demonstrates how you would initialize a buffer string.  Once again,
 if C<$dir> is not initialized (is C<undef>), then a buffer of the default size of 2048
 bytes will be created internally.  You can also allocate a specific number of bytes
 as in the previous example.

--- a/lib/FFI/Platypus/Lang/Win32.pm
+++ b/lib/FFI/Platypus/Lang/Win32.pm
@@ -376,6 +376,10 @@ sure you also require at least that version of Platypus.
 
 The Core Platypus documentation.
 
+=item L<FFI::Platypus::Lang>
+
+Includes a list of other language plugins for Platypus.
+
 =item L<FFI::Platypus::Type::WideString>
 
 The wide string type plugin use for C<LPWSTR> and C<LPCWSTR> types.

--- a/lib/FFI/Platypus/Lang/Win32.pm
+++ b/lib/FFI/Platypus/Lang/Win32.pm
@@ -271,6 +271,14 @@ sub load_custom_types
 
 The Core Platypus documentation.
 
+=item L<FFI::Platypus::Type::WideString>
+
+The wide string type plugin use for C<LPWSTR> and C<LPCWSTR> types.
+
+=item L<Win32::API>
+
+Another FFI, but for Windows only.
+
 =back
 
 =cut

--- a/lib/FFI/Platypus/Memory.pm
+++ b/lib/FFI/Platypus/Memory.pm
@@ -148,6 +148,10 @@ if($@)
   $ffi->attach([ ffi_platypus_memory__strndup => 'strndup' ] => ['string','size_t'] => 'opaque' => '$$');
 }
 
+# used internally by FFI::Platypus::Type::WideString, may go away.
+eval { $ffi->attach( [ wcslen  => '_wcslen' ]  => [ 'opaque'           ] => 'size_t' => '$' ) };
+eval { $ffi->attach( [ wcsnlen => '_wcsnlen' ] => [ 'string', 'size_t' ] => 'size_t' => '$$' ) };
+
 1;
 
 =head1 SEE ALSO

--- a/lib/FFI/Platypus/Memory.pm
+++ b/lib/FFI/Platypus/Memory.pm
@@ -128,8 +128,17 @@ eval {
   $ffi->attach(strdup  => ['string'] => 'opaque' => '$');
   $_strdup_impl = 'libc';
 };
+if($@ && $^O eq 'MSWin32')
+{
+  eval {
+    die "do not use c impl" if ($ENV{FFI_PLATYPUS_MEMORY_STRDUP_IMPL}||'libc') eq 'ffi';
+    $ffi->attach([ _strdup => 'strdup' ] => ['string'] => 'opaque' => '$');
+    $_strdup_impl = 'libc';
+  };
+}
 if($@)
 {
+  warn "using bundled strdup";
   $_strdup_impl = 'ffi';
   $ffi->attach([ ffi_platypus_memory__strdup => 'strdup' ] => ['string'] => 'opaque' => '$');
 }

--- a/lib/FFI/Platypus/Record.pm
+++ b/lib/FFI/Platypus/Record.pm
@@ -42,7 +42,7 @@ Perl:
  
  package main;
  
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  
  my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->lib("myperson.so");

--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -56,7 +56,7 @@ tm
 
 OO Interface:
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->type('int' => 'my_int');
 
@@ -70,7 +70,7 @@ Types may be "defined" ahead of time, or simply used when defining or
 attaching functions.
 
  # Example of defining types
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->type('int');
  $ffi->type('string');
@@ -126,7 +126,7 @@ second argument to the L<FFI::Platypus#type> method can be used to
 define a type alias that can later be used by function declaration
 and attachment.
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->type('int'    => 'myint');
  $ffi->type('string' => 'mystring');
@@ -634,7 +634,7 @@ code.
  }
  
  # foo.pl
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->lib('libfoo.so'); # change to reflect the dynamic lib
                          # that contains foo.c
@@ -904,7 +904,7 @@ constants in your Perl module, like this:
 
  package Foo;
  
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  use base qw( Exporter );
  
  our @EXPORT_OK = qw( FOO_STATIC FOO_DYNAMIC FOO_OTHER foo get_foo );
@@ -928,7 +928,7 @@ function, like this:
 
  package Foo;
  
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  
  our @EXPORT_OK = qw( foo get_foo );
  
@@ -981,7 +981,7 @@ interface like this:
 
  package Foo;
  
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  use FFI::Platypus::API qw( arguments_get_string );
  
  my $ffi = FFI::Platypus->new( api => 1 );

--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -593,6 +593,19 @@ and return an opaque pointer to the string using a cast.
  });
  print_message($get_message);
 
+Another type of string that you may run into with some APIs is the
+so called "wide" string.  In your C code if you see C<wchar_t*>
+or C<const wchar_t*> or if in Win32 API code you see C<LPWSTR>
+or C<LPCWSTR>.  Most commonly you will see these types when working
+with the Win32 API, but you may see them in Unix as well.  These
+types are intended for dealing with Unicode, but they do not use
+the same UTF-8 format used by Perl internally, so they need to be
+converted.  You can do this manually by allocating the memory
+and using the L<Encode> module, but the easier way is to use
+either L<FFI::Platypus::Type::WideString> or
+L<FFI::Platypus::Lang::Win32>, which handle the memory allocation
+and conversion for you.
+
 =head2 Pointer / References
 
 In C you can pass a pointer to a variable to a function in order

--- a/lib/FFI/Platypus/Type/WideString.pm
+++ b/lib/FFI/Platypus/Type/WideString.pm
@@ -439,3 +439,25 @@ sub ffi_custom_type_api_1
 }
 
 1;
+
+=head1 SEE ALSO
+
+=over 4
+
+=item L<FFI::Platypus>
+
+Core Platypus documentation.
+
+=item L<FFI::Platypus::Type>
+
+Includes documentation on handling "normal" 8 bit C strings among others.
+
+=item L<FFI::Platypus::Lang::Win32>
+
+Documentation for using Platypus with C<LPWSTR> and C<LPCWSTR> types on
+Microsoft Windows.  These types are just aliases for the standard C wide
+strings.
+
+=back
+
+=cut

--- a/lib/FFI/Platypus/Type/WideString.pm
+++ b/lib/FFI/Platypus/Type/WideString.pm
@@ -14,7 +14,46 @@ use Carp ();
 
 =head1 SYNOPSIS
 
-# TODO
+ use FFI::Platypus 1.00;
+ 
+ my $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
+ $ffi->load_custom_type('::WideString' => 'wstring', access => 'read' );
+ $ffi->load_custom_type('::WideString' => 'wstring_w', access => 'write' );
+ 
+ # call function that takes a constant wide string
+ $ffi->attach( wcscmp => ['wstring', 'wstring'] => 'int' );
+ my $diff = wcscmp("I ❤ perl + Platypus", "I ❤ perl + Platypus"); # returns 0
+ 
+ # call a function that takes a wide string for writing
+ $ffi->attach( wcscpy => ['wstring_w', 'wstring'] );
+ my $buf;
+ wcscpy(\$buf, "I ❤ perl + Platypus");
+ print $buf, "\n";  # prints "I ❤ perl + Platypus"
+ 
+ # call a function that takes a wide string for modification
+ $ffi->attach( wcscat => ['wstring_w', 'wstring'] );
+ my $buf;
+ wcscat( [ \$buf, "I ❤ perl" ], " + Platypus");
+ print $buf, "\n";  # prints "I ❤ perl + Platypus"
+
+On Windows use with C<LPCWSTR>:
+
+ use FFI::Platypus 1.00;
+ 
+ my $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
+ 
+ # define some custom Win32 Types
+ # to get these automatically see FFI::Platypus::Lang::Win32
+ $ffi->load_custom_type('::WideString' => 'LPCWSTR', access => 'read' );
+ $ffi->type('opaque' => 'HWND');
+ $ffi->type('uint'   => 'UINT');
+ 
+ use constant MB_OK                   => 0x00000000;
+ use constant MB_DEFAULT_DESKTOP_ONLY => 0x00020000;
+ 
+ $ffi->attach( [MessageBoxW => 'MessageBox'] => [ 'HWND', 'LPCWSTR', 'LPCWSTR', 'UINT'] => 'int' );
+ 
+ MessageBox(undef, "I ❤️ Platypus", "Confession", MB_OK|MB_DEFAULT_DESKTOP_ONLY);
 
 =head1 DESCRIPTION
 

--- a/lib/FFI/Platypus/Type/WideString.pm
+++ b/lib/FFI/Platypus/Type/WideString.pm
@@ -30,6 +30,12 @@ my @stack;  # To keep buffer alive.
 
 sub _compute_wide_string_encoding
 {
+  foreach my $need (qw( wcslen wcsnlen ))
+  {
+    die "This type plugin needs $need from libc, and cannot find it"
+      unless FFI::Platypus::Memory->can("_$need");
+  }
+
   my $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
 
   my $size = eval { $ffi->sizeof('wchar_t') };

--- a/lib/FFI/Platypus/Type/WideString.pm
+++ b/lib/FFI/Platypus/Type/WideString.pm
@@ -36,9 +36,11 @@ occasionally find APIs that talk in wide strings.  (libarchive, for example,
 can work in both).
 
 This plugin will detect the native wide string format for you and transparently
-convert Perl strings, which are typically encoded internally as UTF-8.  It can
-be used either for read/write buffers, for const read-only strings, and for
-return values.  It supports these options:
+convert Perl strings, which are typically encoded internally as UTF-8.  If for
+some reason it cannot detect the correct encoding, or if your platform is
+currently supported, an exception will be thrown (please open a ticket if this
+is the case).  It can be used either for read/write buffers, for const read-only
+strings, and for return values.  It supports these options:
 
 Options:
 

--- a/lib/FFI/Platypus/Type/WideString.pm
+++ b/lib/FFI/Platypus/Type/WideString.pm
@@ -1,0 +1,156 @@
+package FFI::Platypus::Type::WideString;
+
+use strict;
+use warnings;
+use 5.008004;
+use FFI::Platypus;
+use FFI::Platypus::Memory ();
+use Encode qw( decode encode );
+use Carp ();
+
+# ABSTRACT: Platypus custom type for Unicode "wide" strings
+# VERSION
+
+=head1 SYNOPSIS
+
+# TODO
+
+=head1 DESCRIPTION
+
+# TODO
+
+=cut
+
+use constant _incantation =>
+  $^O eq 'MSWin32' && do { require Config; $Config::Config{archname} =~ /MSWin32-x64/ }
+    ? 'Q'
+    : 'L!';
+
+my @stack;  # To keep buffer alive.
+
+sub _compute_wide_string_encoding
+{
+  my $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
+
+  my $size = eval { $ffi->sizeof('wchar_t') };
+  die 'no wchar_t' if $@;
+
+  my %orders = (
+    join('', 1..$size)         => 'BE',
+    join('', reverse 1..$size) => 'LE',
+  );
+
+  my $byteorder = join '', @{ $ffi->cast( "wchar_t*", "uint8[$size]", \hex(join '', map { "0$_" } 1..$size) ) };
+
+  my $encoding;
+
+  if($size == 2)
+  {
+    $encoding = 'UTF-16';
+  }
+  elsif($size == 4)
+  {
+    $encoding = 'UTF-32';
+  }
+  else
+  {
+    die "not sure what encoding to use for size $size";
+  }
+
+  if(defined $orders{$byteorder})
+  {
+    $encoding .= $orders{$byteorder};
+  }
+  else
+  {
+    die "odd byteorder $byteorder not (yet) supported";
+  }
+
+  return ($encoding, $size);
+}
+
+my $encoding;
+my $width;
+
+sub perl_to_native
+{
+  if(defined $_[0])
+  {
+    my $buf = encode($encoding, $_[0]."\0");
+    push @stack, \$buf;
+    return unpack(_incantation, pack 'P', $buf);
+  }
+  else
+  {
+    push @stack, undef;
+    return undef;
+  }
+}
+
+sub perl_to_native_post
+{
+  pop @stack;
+  return;
+}
+
+sub native_to_perl
+{
+  return undef unless defined $_[0];
+  return decode($encoding, unpack('P'.(FFI::Platypus::Memory::_wcslen($_[0])*$width), pack(_incantation, $_[0])));
+}
+
+sub ffi_custom_type_api_1
+{
+  my %args = @_;
+
+  ($encoding, $width) = __PACKAGE__->_compute_wide_string_encoding() unless defined $encoding;
+
+  my $size   = $args{size} || 1024;
+  my $access = $args{access} || 'read';
+
+  my %ct = (
+    native_type    => 'opaque',
+    native_to_perl => \&native_to_perl,
+  );
+
+  if($access eq 'read')
+  {
+    $ct{perl_to_native}      = \&perl_to_native;
+    $ct{perl_to_native_post} = \&perl_to_native_post;
+  }
+  elsif($access eq 'write')
+  {
+    my @stack;
+
+    $ct{perl_to_native} = sub {
+      my $ref = shift;
+      push @stack, $ref;
+      if(ref($ref) eq 'SCALAR')
+      {
+        $$ref = "\0" x $size unless defined $$ref;
+        return unpack(_incantation, pack 'P', $$ref);
+      }
+      else
+      {
+        return undef;
+      }
+    };
+
+    $ct{perl_to_native_post} = sub {
+      my $ref = pop @stack;
+      return unless defined $ref;
+      my $len = length $$ref;
+      $len = FFI::Platypus::Memory::_wcsnlen($$ref, $len);
+      $$ref = decode($encoding, substr($$ref, 0, $len*$width));
+    };
+
+  }
+  else
+  {
+    Carp::croak("Unknown access type $access");
+  }
+
+  return \%ct;
+}
+
+1;

--- a/lib/FFI/Platypus/TypeParser/Version1.pm
+++ b/lib/FFI/Platypus/TypeParser/Version1.pm
@@ -11,7 +11,7 @@ use base qw( FFI::Platypus::TypeParser );
 
 =head1 SYNOPSIS
 
- use FFI::Platypus;
+ use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
  $ffi->type('record(Foo::Bar)' => 'foo_bar_t');
  $ffi->type('record(Foo::Bar)*' => 'foo_bar_ptr');

--- a/maint/cip-before-install
+++ b/maint/cip-before-install
@@ -6,10 +6,10 @@ cip sudo apt-get update
 cip sudo apt-get install libffi-dev
 cip exec cpanm -n version
 
-if [ "$CIP_TAG" == "5.30-debug" ]; then
+if [ "$CIP_TAG" == "5.32-debug" ]; then
   cip exec cpanm -n Test::LeakTrace
 fi
 
-if [ "$CIP_TAG" == "5.30-debug32" ]; then
+if [ "$CIP_TAG" == "5.32-debug32" ]; then
   cip exec cpanm -n Test::LeakTrace
 fi

--- a/t/01_use.t
+++ b/t/01_use.t
@@ -33,6 +33,7 @@ require_ok 'FFI::Platypus::Type';
 require_ok 'FFI::Platypus::Type::PointerSizeBuffer';
 require_ok 'FFI::Platypus::Type::StringArray';
 require_ok 'FFI::Platypus::Type::StringPointer';
+require_ok 'FFI::Platypus::Type::WideString';
 require_ok 'FFI::Platypus::TypeParser';
 require_ok 'FFI::Platypus::TypeParser::Version0';
 require_ok 'FFI::Platypus::TypeParser::Version1';
@@ -72,6 +73,7 @@ ok -f 't/ffi_platypus_type.t',                                'test for FFI::Pla
 ok -f 't/ffi_platypus_type_pointersizebuffer.t',              'test for FFI::Platypus::Type::PointerSizeBuffer';
 ok -f 't/ffi_platypus_type_stringarray.t',                    'test for FFI::Platypus::Type::StringArray';
 ok -f 't/ffi_platypus_type_stringpointer.t',                  'test for FFI::Platypus::Type::StringPointer';
+ok -f 't/ffi_platypus_type_widestring.t',                     'test for FFI::Platypus::Type::WideString';
 ok -f 't/ffi_platypus_typeparser.t',                          'test for FFI::Platypus::TypeParser';
 ok -f 't/ffi_platypus_typeparser_version0.t',                 'test for FFI::Platypus::TypeParser::Version0';
 ok -f 't/ffi_platypus_typeparser_version1.t',                 'test for FFI::Platypus::TypeParser::Version1';

--- a/t/ffi_platypus_lang_win32.t
+++ b/t/ffi_platypus_lang_win32.t
@@ -3,14 +3,73 @@ use warnings;
 use Test::More;
 use FFI::Platypus::Lang::Win32;
 
-my $map = FFI::Platypus::Lang::Win32->native_type_map;
-
-foreach my $alias (sort keys %$map)
 {
-  my $type = $map->{$alias};
-  note sprintf("%-30s %s", $alias, $type);
+  require FFI::Platypus::Type::WideString;
+  my($encoding,$width) = eval { FFI::Platypus::Type::WideString->_compute_wide_string_encoding() };
+  if(my $error = $@)
+  {
+    $error =~ s/ at .*$//;
+    plan skip_all => "Unable to detect wide string details: $error\n";
+  }
+
+  note "encoding = $encoding";
+  note "width    = $width";
 }
 
-pass 'good';
+subtest 'native type map diagnostic' => sub {
+
+  my $map = FFI::Platypus::Lang::Win32->native_type_map;
+
+  foreach my $alias (sort keys %$map)
+  {
+    my $type = $map->{$alias};
+    note sprintf("%-30s %s", $alias, $type);
+  }
+
+  pass 'good';
+};
+
+my $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
+
+subtest 'load' => sub {
+  local $@ = "";
+  eval { $ffi->lang('Win32') };
+  is "$@", "";
+};
+
+my @strings = (
+  [ "trivial" => "" ],
+  [ "simple"  => "abcde" ],
+  [ "fancy"   => "abcd\x{E9}" ],
+  [ "complex" => "I \x{2764} Platypus" ],
+);
+
+subtest 'LPCWSTR' => sub {
+  plan skip_all => 'Test only works on Windows' unless $^O eq 'MSWin32';
+
+  my $lstrlenW = $ffi->function( lstrlenW => [ 'LPCWSTR' ] => 'int' );
+
+  foreach my $test (@strings)
+  {
+    my($name, $string) = @$test;
+   is($lstrlenW->call($string), length($string), $name);
+  }
+};
+
+subtest 'LPWSTR' => sub {
+  plan skip_all => 'Test only works on Windows' unless $^O eq 'MSWin32';
+
+  my $GetCurrentDirectoryW = $ffi->function( GetCurrentDirectoryW => ['DWORD','LPWSTR'] => 'DWORD' );
+
+  my $size = $GetCurrentDirectoryW->call(0, undef);
+  cmp_ok $size, '>', 0;
+
+  my $buf = "\0" x ($size*2);
+  $GetCurrentDirectoryW->call($size, \$buf);
+
+  note "buf = $buf";
+
+  ok( -d $buf, "returned directory exists");
+};
 
 done_testing;

--- a/t/ffi_platypus_type_widestring.t
+++ b/t/ffi_platypus_type_widestring.t
@@ -91,7 +91,7 @@ subtest 'wide string as argument (in)' => sub {
 
 subtest 'wide string as argument (out)' => sub {
 
-  my $wcscpy = $ffi->function( wcscpy => ['wstring_w','wstring'] => 'wstring' );
+  my $wcscpy = $ffi->function( wcscpy => ['wstring_w','wstring'] );
   plan skip_all => 'Test requires wcscpy' unless defined $wcscpy;
 
   foreach my $test (@strings)
@@ -128,7 +128,7 @@ subtest 'wide string as a return value' => sub {
 
 subtest 'wide string as in-out argument' => sub {
 
-  my $wcscat = $ffi->function( wcscat => ['wstring_w','wstring'] => 'wstring' );
+  my $wcscat = $ffi->function( wcscat => ['wstring_w','wstring'] );
   plan skip_all => 'Test requires wcscat' unless defined $wcscat;
 
   foreach my $test (@strings)

--- a/t/ffi_platypus_type_widestring.t
+++ b/t/ffi_platypus_type_widestring.t
@@ -1,0 +1,120 @@
+use strict;
+use warnings;
+use open ':std', ':encoding(utf8)';
+use Test::More;
+use FFI::CheckLib;
+use FFI::Platypus;
+use FFI::Platypus::Memory qw( free strdup );
+use FFI::Platypus::Type::WideString;
+
+my($encoding,$width) = eval { FFI::Platypus::Type::WideString->_compute_wide_string_encoding() };
+
+if(my $error = $@)
+{
+  $error =~ s/ at .*$//;
+  plan skip_all => "Unable to detect wide string details: $error\n";
+}
+
+# This test assumes a wchar_t of at least 2 bytes, which is probably true
+# everywhere Platypus is actually suppored, but wchar_t could technically
+# be the same size as char.
+
+note "encoding = $encoding";
+note "width    = $width";
+
+my @lib = find_lib lib => 'test', symbol => 'f0', libpath => 't/ffi';
+push @lib, undef;
+
+my $ffi = FFI::Platypus->new( api => 1, lib => \@lib );
+$ffi->ignore_not_found(1);
+$ffi->load_custom_type('::WideString' => 'wstring');
+$ffi->load_custom_type('::WideString' => 'wstring_w', access => 'write');
+
+our $ptr;
+my $wcsdup = $ffi->function( wcsdup => ['wstring'] => 'opaque' => sub{
+  my $xsub = shift;
+  free $ptr if defined $ptr;
+  $ptr = undef;
+  $ptr = $xsub->(@_);
+});
+
+END { free $ptr if defined $ptr; undef $ptr };
+
+
+subtest 'wcschr' => sub {
+
+  my $wcschr = $ffi->function( wcschr => ['opaque','wchar_t'] => 'wstring' );
+  plan skip_all => 'Test requires wcschr' unless defined $wcschr;
+  plan skip_all => 'Test requires wcsdup' unless defined $wcsdup;
+
+  is( $ffi->cast( opaque => 'wstring', $wcsdup->call("I \x{2764} Platypus")), "I \x{2764} Platypus" );
+
+  # make sure libc is using the same wchar_t as we are.
+  # also tests "in as argument" mode.
+  is( $wcschr->call($wcsdup->call('foobar'),              ord('b')),        'bar');
+  is( $wcschr->call($wcsdup->call("I \x{2764} Platypus"), ord("\x{2764}")), "\x{2764} Platypus");
+
+};
+
+my @strings = (
+  [ "trivial" => "" ],
+  [ "simple"  => "abcde" ],
+  [ "fancy"   => "abcd\x{E9}" ],
+  [ "complex" => "I \x{2764} Platypus" ],
+);
+
+subtest 'wide string as argument (in)' => sub {
+
+  my $wcslen = $ffi->function( wcslen => ['wstring'] => 'size_t' );
+  plan skip_all => 'Test requires wcslen' unless defined $wcslen;
+
+  foreach my $test (@strings)
+  {
+    my($name, $string) = @$test;
+    # note: this works because on Windows with UTF_16
+    # because all of our test strings are in the BMP
+    is($wcslen->call($string), length($string), $name);
+  }
+
+  is($ffi->cast( 'wstring', 'opaque', undef), undef, 'NULL');
+
+};
+
+subtest 'wide string as argument (out)' => sub {
+
+  my $wcscpy = $ffi->function( wcscpy => ['wstring_w','wstring'] => 'wstring' );
+  plan skip_all => 'Test requires wcscpy' unless defined $wcscpy;
+
+  foreach my $test (@strings)
+  {
+    my($name, $string) = @$test;
+
+    my $out1;
+    $wcscpy->call(\$out1, $string);
+    is($out1, $string, "$name default buffer size");
+
+    my $out2 = "\0" x ($width * (length($string)+1));
+    $wcscpy->call(\$out2, $string);
+    is($out2, $string, "$name with just enough buffer");
+  }
+
+  my $is_null = $ffi->function( pointer_is_null => ['wstring_w'] => 'int' );
+  ok($is_null->call(undef), "NULL");
+};
+
+subtest 'wide string as a return value' => sub {
+
+  plan skip_all => 'Test requires wcsdup' unless defined $wcsdup;
+
+  foreach my $test (@strings)
+  {
+    my($name, $string) = @$test;
+    $wcsdup->($string);
+    is($ffi->cast('opaque','wstring', $ptr), $string, $name);
+  }
+
+  is($ffi->cast('opaque','wstring', undef), undef, 'NULL');
+
+};
+
+done_testing;

--- a/t/ffi_platypus_type_widestring.t
+++ b/t/ffi_platypus_type_widestring.t
@@ -50,9 +50,6 @@ my $wcsdup = do {
   $wcsdup;
 };
 
-
-
-
 subtest 'wcschr' => sub {
 
   my $wcschr = $ffi->function( wcschr => ['opaque','wchar_t'] => 'wstring' );
@@ -126,6 +123,26 @@ subtest 'wide string as a return value' => sub {
   }
 
   is($ffi->cast('opaque','wstring', undef), undef, 'NULL');
+
+};
+
+subtest 'wide string as in-out argument' => sub {
+
+  my $wcscat = $ffi->function( wcscat => ['wstring_w','wstring'] => 'wstring' );
+  plan skip_all => 'Test requires wcscat' unless defined $wcscat;
+
+  foreach my $test (@strings)
+  {
+    my($name, $string) = @$test;
+
+    my $out1;
+    $wcscat->call([\$out1, $string], $string);
+    is($out1, "$string$string", "$name default buffer size");
+
+    my $out2 = "\0" x ($width * (length($string)*2+1));
+    $wcscat->call([\$out2, $string], $string);
+    is($out2, "$string$string", "$name with just enough buffer");
+  }
 
 };
 

--- a/t/ffi_platypus_type_widestring.t
+++ b/t/ffi_platypus_type_widestring.t
@@ -22,8 +22,8 @@ if(my $error = $@)
 note "encoding = $encoding";
 note "width    = $width";
 
-my @lib = find_lib lib => 'test', symbol => 'f0', libpath => 't/ffi';
-push @lib, undef;
+my @lib = find_lib lib => 'test', symbol => 'f0', libpath => 't/ffi';  # need test lib for pointer_is_null
+push @lib, undef;                                                      # for libc wcs* functions
 
 my $ffi = FFI::Platypus->new( api => 1, lib => \@lib );
 $ffi->ignore_not_found(1);


### PR DESCRIPTION
Add support for wide strings via a new plugin.  In the C standard this is `const wchar_t *` and `wchar_t *` where `wchar_t` are usually either 2 or 4 bytes.  In Windows this is UCS-2 later evolved to be UTF-16LE.

Also add some hooks in the Win32 plugins to add what they refer to as wide strings: `LPWSTR` and `LPCWSTR` but are really just aliases on the `wchar_t` strings used by the C standard.  I think this form of wide string is common enough in the Win32 API that it makes sense to just always load these types.

Arguably this should be added to the (default) C language plugin as well, but I think in practice these types are rarely enough used in non-Win32 APIs that it isn't worth the overhead.

This is heavily based on #292 but is generalized to the C standard rather than the Windows API.  This form also doesn't require mucking about with pointers for the read/write buffer case.  The read/write buffer case is a little awkward in my opinion, but I think it is less error-prone and less verbose than using pointers.  For cases where you really do want to muck about with pointers (I think there probably are cases) you can still do this using `wcs*` functions provided by libc.