### PR TITLE
Add support for passing record values into a closure

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Add support for closures taking records pass-by-value (gh#312)
 
 1.38      2021-03-08 17:13:15 -0700
   - Production release identical to 1.37_01

--- a/lib/FFI/Platypus/Record.pm
+++ b/lib/FFI/Platypus/Record.pm
@@ -34,11 +34,11 @@ Perl:
  
  use FFI::Platypus::Record;
  
- record_layout_1(qw(
-   int       age
-   string(3) title
-   string_rw name
- ));
+ record_layout_1(
+   'int'       => 'age',
+   'string(3)' => 'title',
+   'string rw' => 'name',
+ );
  
  package main;
  
@@ -87,7 +87,7 @@ Supports:
 
 =item C pointers to C<struct> types
 
-=item Passing C <struct>s by-value.
+=item Passing C C<struct>s by-value.
 
 =back
 

--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -766,6 +766,13 @@ record, and finally freeing the original pointer.
  my $foo = $ffi->cast( 'opaque' => 'foo_t*', $foo_ptr );
  free $foo_ptr;
 
+You can pass records into a closure, but care needs to be taken.
+Records passed into a closure are read-only inside the closure,
+including C<string rw> members.  Although you can pass a "pointer"
+to a record into a closure, because of limitations of the
+implementation you actually have a copy, so all records passed
+into closures are passed by-value.
+
 =head2 Fixed length arrays
 
 Fixed length arrays of native types and strings are supported by
@@ -813,16 +820,17 @@ A closure (sometimes called a "callback", we use the C<libffi>
 terminology) is a Perl subroutine that can be called from C.  In order
 to be called from C it needs to be passed to a C function.  To define
 the closure type you need to provide a list of argument types and a
-return type.  As of this writing only native types and strings are
-supported as closure argument types and only native types are supported
-as closure return types.  Here is an example, with C code:
+return type.  Currently only native types (integers, floating point
+values, opaque), strings and records (by-value; you can pass a pointer
+to a record, but due to limitations of the record implementation this
+is actually a copy) are supported as closure argument types, and only
+native types are supported as closure return types.  Inside the closure
+any records passed in are read-only.
 
-[ version 0.54 ]
+We plan to add other types, though they can be converted using the Platypus
+C<cast> or C<attach_cast> methods.
 
-EXPERIMENTAL: As of version 0.54, the record type (see L<FFI::Platypus::Record>)
-is also experimentally supported as a closure argument type.  One
-caveat is that  the record member type string_rw is NOT supported
-and probably never will be.
+Here is an example, with C code:
 
 # EXAMPLE: examples/closure.c
 

--- a/t/ffi/closure.c
+++ b/t/ffi/closure.c
@@ -60,3 +60,18 @@ cx_closure_call(cx_struct_t *s, int i)
 {
   my_cx_closure(s, i);
 }
+
+typedef void (*cxv_closure_t)(cx_struct_t, int);
+static cxv_closure_t my_cxv_closure;
+
+EXTERN void
+cxv_closure_set(cxv_closure_t closure)
+{
+  my_cxv_closure = closure;
+}
+
+EXTERN void
+cxv_closure_call(cx_struct_t s, int i)
+{
+  my_cxv_closure(s, i);
+}

--- a/xs/TypeParser.xs
+++ b/xs/TypeParser.xs
@@ -288,9 +288,12 @@ create_type_closure(self, return_type, ...)
         case FFI_PL_TYPE_RECORD:
           ffi_argument_types[i] = &ffi_type_pointer;
           break;
+        case FFI_PL_TYPE_RECORD_VALUE:
+          ffi_argument_types[i] = type->extra[0].closure.argument_types[i]->extra[0].record.ffi_type;
+          break;
         default:
           Safefree(ffi_argument_types);
-          croak("Only native types and strings are supported as closure argument types (%d)", return_type->type_code);
+          croak("Only native types and strings are supported as closure argument types (%d)", type->extra[0].closure.argument_types[i]->type_code);
           break;
       }
     }

--- a/xs/closure.c
+++ b/xs/closure.c
@@ -60,7 +60,7 @@ ffi_pl_closure_call(ffi_cif *ffi_cif, void *result, void **arguments, void *user
   int flags = extra->flags;
   int i;
   int count;
-  SV *sv;
+  SV *sv,*ref;
 
   if(!(flags & G_NOARGS))
   {
@@ -149,7 +149,7 @@ ffi_pl_closure_call(ffi_cif *ffi_cif, void *result, void **arguments, void *user
             sv_setpvn(sv, *((char**)arguments[i]), extra->argument_types[i]->extra[0].record.size);
             if(extra->argument_types[i]->extra[0].record.class != NULL)
             {
-              SV *ref = newRV_inc(sv);
+              ref = newRV_inc(sv);
               sv_bless(ref, gv_stashpv(extra->argument_types[i]->extra[0].record.class, GV_ADD));
               SvREADONLY_on(sv);
               sv = ref;
@@ -160,6 +160,14 @@ ffi_pl_closure_call(ffi_cif *ffi_cif, void *result, void **arguments, void *user
             }
           }
           XPUSHs(sv);
+          break;
+        case FFI_PL_TYPE_RECORD_VALUE:
+          sv = sv_newmortal();
+          sv_setpvn(sv, (char*)arguments[i], extra->argument_types[i]->extra[0].record.size);
+          ref = newRV_inc(sv);
+          sv_bless(ref, gv_stashpv(extra->argument_types[i]->extra[0].record.class, GV_ADD));
+          SvREADONLY_on(sv);
+          XPUSHs(ref);
           break;
         default:
           warn("bad type");


### PR DESCRIPTION
This allows passing records into closures-by-value.  Actually the way we pass pointers to records into closures is also by-value, but don't tell anyone.  Update the documentation in `Type.pm` to reflect the new reality.

This also fixes some documentation errors that I found.