### PR TITLE
Support returning (some) records-by-value from a closure

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Add support for closures returning records pass-by-value
+    if they do not include string pointers (gh#315)
 
 1.39_01   2021-03-09 17:38:37 -0700
   - Fix bug where closure ABI wasn't being used for non-default

--- a/ffi/record_meta.c
+++ b/ffi/record_meta.c
@@ -8,6 +8,7 @@
 #define EXPORT
 #endif
 
+/* TODO: tis is replicated in ffi_platypus.h, which is bad */
 typedef struct _ffi_pl_record_meta_t {
   ffi_type top;
   int can_return_from_closure;

--- a/ffi/record_meta.c
+++ b/ffi/record_meta.c
@@ -1,19 +1,10 @@
-#include <ffi.h>
-#include <stdlib.h>
-#include <string.h>
+#include <ffi_platypus.h>
 
 #ifdef _MSC_VER
 #define EXPORT __declspec(dllexport)
 #else
 #define EXPORT
 #endif
-
-/* TODO: tis is replicated in ffi_platypus.h, which is bad */
-typedef struct _ffi_pl_record_meta_t {
-  ffi_type ffi_type;
-  int can_return_from_closure;
-  ffi_type *elements[0];
-} ffi_pl_record_meta_t;
 
 /*
  * Question: this is the documented way of creating a struct type.

--- a/ffi/record_meta.c
+++ b/ffi/record_meta.c
@@ -10,6 +10,7 @@
 
 typedef struct meta_t {
   ffi_type top;
+  int can_return_from_closure;
   ffi_type *elements[0];
 } meta_t;
 
@@ -21,7 +22,7 @@ typedef struct meta_t {
 
 EXPORT
 meta_t *
-ffi_platypus_record_meta__new(ffi_type *list[])
+ffi_platypus_record_meta__new(ffi_type *list[], int safe_to_return_From_closure)
 {
   int size, i;
   meta_t *t;
@@ -37,6 +38,8 @@ ffi_platypus_record_meta__new(ffi_type *list[])
   t->top.alignment = 0;
   t->top.type      = FFI_TYPE_STRUCT;
   t->top.elements  = (ffi_type**) &t->elements;
+
+  t->can_return_from_closure = safe_to_return_From_closure;
 
 
   for(i=0; i<size+1; i++)
@@ -73,6 +76,13 @@ ffi_type **
 ffi_platypus_record_meta__element_pointers(meta_t *t)
 {
   return t->top.elements;
+}
+
+EXPORT
+int
+ffi_platypus_record_meta__can_return_from_closure(meta_t *t)
+{
+  return t->can_return_from_closure;
 }
 
 EXPORT

--- a/ffi/record_meta.c
+++ b/ffi/record_meta.c
@@ -10,7 +10,7 @@
 
 /* TODO: tis is replicated in ffi_platypus.h, which is bad */
 typedef struct _ffi_pl_record_meta_t {
-  ffi_type top;
+  ffi_type ffi_type;
   int can_return_from_closure;
   ffi_type *elements[0];
 } ffi_pl_record_meta_t;
@@ -35,10 +35,10 @@ ffi_platypus_record_meta__new(ffi_type *list[], int safe_to_return_from_closure)
   if(t == NULL)
     return NULL;
 
-  t->top.size      = 0;
-  t->top.alignment = 0;
-  t->top.type      = FFI_TYPE_STRUCT;
-  t->top.elements  = (ffi_type**) &t->elements;
+  t->ffi_type.size      = 0;
+  t->ffi_type.alignment = 0;
+  t->ffi_type.type      = FFI_TYPE_STRUCT;
+  t->ffi_type.elements  = (ffi_type**) &t->elements;
 
   t->can_return_from_closure = safe_to_return_from_closure;
 
@@ -55,28 +55,28 @@ EXPORT
 ffi_type *
 ffi_platypus_record_meta__ffi_type(ffi_pl_record_meta_t *t)
 {
-  return &t->top;
+  return &t->ffi_type;
 }
 
 EXPORT
 size_t
 ffi_platypus_record_meta__size(ffi_pl_record_meta_t *t)
 {
-  return t->top.size;
+  return t->ffi_type.size;
 }
 
 EXPORT
 unsigned short
 ffi_platypus_record_meta__alignment(ffi_pl_record_meta_t *t)
 {
-  return t->top.alignment;
+  return t->ffi_type.alignment;
 }
 
 EXPORT
 ffi_type **
 ffi_platypus_record_meta__element_pointers(ffi_pl_record_meta_t *t)
 {
-  return t->top.elements;
+  return t->ffi_type.elements;
 }
 
 EXPORT

--- a/ffi/record_meta.c
+++ b/ffi/record_meta.c
@@ -8,11 +8,11 @@
 #define EXPORT
 #endif
 
-typedef struct meta_t {
+typedef struct _ffi_pl_record_meta_t {
   ffi_type top;
   int can_return_from_closure;
   ffi_type *elements[0];
-} meta_t;
+} ffi_pl_record_meta_t;
 
 /*
  * Question: this is the documented way of creating a struct type.
@@ -21,16 +21,16 @@ typedef struct meta_t {
  */
 
 EXPORT
-meta_t *
-ffi_platypus_record_meta__new(ffi_type *list[], int safe_to_return_From_closure)
+ffi_pl_record_meta_t *
+ffi_platypus_record_meta__new(ffi_type *list[], int safe_to_return_from_closure)
 {
   int size, i;
-  meta_t *t;
+  ffi_pl_record_meta_t *t;
 
   for(size=0; list[size] != NULL; size++)
     ;
 
-  t = malloc(sizeof(meta_t) + sizeof(ffi_type*)*(size+1) );
+  t = malloc(sizeof(ffi_pl_record_meta_t) + sizeof(ffi_type*)*(size+1) );
   if(t == NULL)
     return NULL;
 
@@ -39,7 +39,7 @@ ffi_platypus_record_meta__new(ffi_type *list[], int safe_to_return_From_closure)
   t->top.type      = FFI_TYPE_STRUCT;
   t->top.elements  = (ffi_type**) &t->elements;
 
-  t->can_return_from_closure = safe_to_return_From_closure;
+  t->can_return_from_closure = safe_to_return_from_closure;
 
 
   for(i=0; i<size+1; i++)
@@ -52,42 +52,35 @@ ffi_platypus_record_meta__new(ffi_type *list[], int safe_to_return_From_closure)
 
 EXPORT
 ffi_type *
-ffi_platypus_record_meta__ffi_type(meta_t *t)
+ffi_platypus_record_meta__ffi_type(ffi_pl_record_meta_t *t)
 {
   return &t->top;
 }
 
 EXPORT
 size_t
-ffi_platypus_record_meta__size(meta_t *t)
+ffi_platypus_record_meta__size(ffi_pl_record_meta_t *t)
 {
   return t->top.size;
 }
 
 EXPORT
 unsigned short
-ffi_platypus_record_meta__alignment(meta_t *t)
+ffi_platypus_record_meta__alignment(ffi_pl_record_meta_t *t)
 {
   return t->top.alignment;
 }
 
 EXPORT
 ffi_type **
-ffi_platypus_record_meta__element_pointers(meta_t *t)
+ffi_platypus_record_meta__element_pointers(ffi_pl_record_meta_t *t)
 {
   return t->top.elements;
 }
 
 EXPORT
-int
-ffi_platypus_record_meta__can_return_from_closure(meta_t *t)
-{
-  return t->can_return_from_closure;
-}
-
-EXPORT
 void
-ffi_platypus_record_meta__DESTROY(meta_t *t)
+ffi_platypus_record_meta__DESTROY(ffi_pl_record_meta_t *t)
 {
   free(t);
 }

--- a/inc/mm-build.pl
+++ b/inc/mm-build.pl
@@ -33,7 +33,7 @@ my $lib = FFI::Build->new(
   dir      => 'blib/lib/auto/share/dist/FFI-Platypus/lib',
   platform => $config->platform,
   alien    => [$config->alien],
-  cflags   => '-Iblib/lib/auto/share/dist/FFI-Platypus/include',
+  cflags   => '-Iblib/lib/auto/share/dist/FFI-Platypus/include -Iinclude',
 )->build;
 
 my $name = basename($lib->basename);

--- a/include/ffi_platypus.h
+++ b/include/ffi_platypus.h
@@ -158,6 +158,12 @@ typedef struct _ffi_pl_type_extra_object {
   char *class; /* base class */
 } ffi_pl_type_extra_object;
 
+typedef struct _ffi_pl_record_meta_t {
+  ffi_type top;
+  int can_return_from_closure;
+  ffi_type *elements[0];
+} ffi_pl_record_meta_t;
+
 typedef struct _ffi_pl_type_extra_record {
   size_t size;
   char *class; /* base class */

--- a/include/ffi_platypus.h
+++ b/include/ffi_platypus.h
@@ -159,15 +159,15 @@ typedef struct _ffi_pl_type_extra_object {
 } ffi_pl_type_extra_object;
 
 typedef struct _ffi_pl_record_meta_t {
-  ffi_type top;
-  int can_return_from_closure;
+  ffi_type ffi_type;
+  int  can_return_from_closure;
   ffi_type *elements[0];
 } ffi_pl_record_meta_t;
 
 typedef struct _ffi_pl_type_extra_record {
   size_t size;
   char *class; /* base class */
-  ffi_type *ffi_type;
+  ffi_pl_record_meta_t *meta;
 } ffi_pl_type_extra_record;
 
 typedef struct _ffi_pl_type_extra_custom_perl {

--- a/lib/FFI/Platypus/Record.pm
+++ b/lib/FFI/Platypus/Record.pm
@@ -342,6 +342,7 @@ sub record_layout
 
   my @destroy;
   my @ffi_types;
+  my $has_string;
 
   while(@_)
   {
@@ -355,10 +356,10 @@ sub record_layout
     croak "accessor/method $name already exists"
       if $caller->can($name);
 
-    my $size  = $type->sizeof;
-    my $align = $type->alignof;
+    my $size      = $type->sizeof;
+    my $align     = $type->alignof;
     $record_align = $align if $align > $record_align;
-    my $meta  = $type->meta;
+    my $meta      = $type->meta;
 
     $offset++ while $offset % $align;
 
@@ -373,9 +374,13 @@ sub record_layout
       }
       else
       {
+        use YAML ();
+        warn YAML::Dump($meta);
         $ffi_type = $meta->{ffi_type};
         $count    = $meta->{element_count};
         $count    = 1 unless defined $count;
+
+        $has_string = 1 if $meta->{type} eq 'string';
       }
       push @ffi_types, $ffi_type for 1..$count;
     }

--- a/lib/FFI/Platypus/Record.pm
+++ b/lib/FFI/Platypus/Record.pm
@@ -374,8 +374,6 @@ sub record_layout
       }
       else
       {
-        use YAML ();
-        warn YAML::Dump($meta);
         $ffi_type = $meta->{ffi_type};
         $count    = $meta->{element_count};
         $count    = 1 unless defined $count;
@@ -439,6 +437,7 @@ sub record_layout
     require FFI::Platypus::Record::Meta;
     my $ffi_meta = FFI::Platypus::Record::Meta->new(
       \@ffi_types,
+      !$has_string,
     );
     *{join '::', $caller, '_ffi_meta'} = sub { $ffi_meta };
   }

--- a/lib/FFI/Platypus/Record/Meta.pm
+++ b/lib/FFI/Platypus/Record/Meta.pm
@@ -37,8 +37,8 @@ the public interface to Platypus records.
 
   $ffi->attach( _find_symbol => ['string'] => 'ffi_type');
 
-  $ffi->attach( new => ['ffi_type[]'] => 'meta_t', sub {
-    my($xsub, $class, $elements) = @_;
+  $ffi->attach( new => ['ffi_type[]','int'] => 'meta_t', sub {
+    my($xsub, $class, $elements, $closure_safe) = @_;
 
     if(ref($elements) ne 'ARRAY')
     {
@@ -63,7 +63,7 @@ the public interface to Platypus records.
 
     push @element_type_pointers, undef;
 
-    my $ptr = $xsub->(\@element_type_pointers);
+    my $ptr = $xsub->(\@element_type_pointers, $closure_safe);
     bless \$ptr, $class;
   });
 

--- a/lib/FFI/Platypus/Record/Meta.pm
+++ b/lib/FFI/Platypus/Record/Meta.pm
@@ -75,4 +75,6 @@ the public interface to Platypus records.
   $ffi->attach( DESTROY          => ['meta_t'] => 'void'       );
 }
 
+sub ptr { ${ shift() } }
+
 1;

--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -824,8 +824,10 @@ return type.  Currently only native types (integers, floating point
 values, opaque), strings and records (by-value; you can pass a pointer
 to a record, but due to limitations of the record implementation this
 is actually a copy) are supported as closure argument types, and only
-native types are supported as closure return types.  Inside the closure
-any records passed in are read-only.
+native types and records (by-value; pointer records and records with
+string pointers cannot be returned from a closure) are supported as
+closure return types.  Inside the closure any records passed in are
+read-only.
 
 We plan to add other types, though they can be converted using the Platypus
 C<cast> or C<attach_cast> methods.

--- a/lib/FFI/Platypus/TypeParser/Version1.pm
+++ b/lib/FFI/Platypus/TypeParser/Version1.pm
@@ -167,11 +167,12 @@ sub parse
     }
     else
     {
+      $DB::single = 1;
       return $self->types->{$name} = $self->create_type_record(
         1,
         $class->$size_method,
         $class,
-        $class->_ffi_meta->ffi_type,
+        $class->_ffi_meta->ptr,
       );
     }
   }

--- a/lib/FFI/Platypus/TypeParser/Version1.pm
+++ b/lib/FFI/Platypus/TypeParser/Version1.pm
@@ -167,7 +167,6 @@ sub parse
     }
     else
     {
-      $DB::single = 1;
       return $self->types->{$name} = $self->create_type_record(
         1,
         $class->$size_method,

--- a/t/ffi/closure.c
+++ b/t/ffi/closure.c
@@ -75,3 +75,17 @@ cxv_closure_call(cx_struct_t s, int i)
 {
   my_cxv_closure(s, i);
 }
+
+typedef struct {
+  char  foo;
+  short bar;
+  int   baz;
+} cx_struct_simple_t;
+
+typedef cx_struct_simple_t (*cxv_closure_simple_t)(void);
+
+EXTERN cx_struct_simple_t
+cxv_closure_simple_call(cxv_closure_simple_t closure)
+{
+  return closure();
+}

--- a/t/type_record.t
+++ b/t/type_record.t
@@ -88,7 +88,7 @@ subtest 'is a reference' => sub {
 
 subtest 'closure' => sub {
 
-  { package Closture::Record::RW;
+  { package Closure::Record::RW;
 
     use FFI::Platypus::Record;
 
@@ -106,14 +106,14 @@ subtest 'closure' => sub {
 
   my $ffi = FFI::Platypus->new( lib => [@lib] );
 
-  $ffi->type('record(Closture::Record::RW)' => 'cx_struct_rw_t');
+  $ffi->type('record(Closure::Record::RW)' => 'cx_struct_rw_t');
   eval { $ffi->type('(cx_struct_rw_t,int)->void' => 'cx_closure_t') };
   is $@, '', 'allow record type as arg';
 
   my $cx_closure_set = $ffi->function(cx_closure_set => [ 'cx_closure_t' ] => 'void' );
   my $cx_closure_call = $ffi->function(cx_closure_call => [ 'cx_struct_rw_t', 'int' ] => 'void' );
 
-  my $r = Closture::Record::RW->new;
+  my $r = Closure::Record::RW->new;
   $r->one("one");
   $r->two("two");
   $r->three(3);

--- a/t/type_record_value.t
+++ b/t/type_record_value.t
@@ -126,7 +126,7 @@ subtest 'closure' => sub {
   {
     local $@ = '';
     eval { $ffi->type('()->cx_struct_rw_t' )  };
-    like "$@", qr/Only native types are supported as closure return types/, 'do not allow record type with pointer strings as ret type';
+    like "$@", qr/Record return type contains types that cannot be returned from a closure/, 'do not allow record type with pointer strings as ret type';
   }
 
   my $cxv_closure_set = $ffi->function(cxv_closure_set => [ 'cxv_closure_t' ] => 'void' );

--- a/t/type_record_value.t
+++ b/t/type_record_value.t
@@ -261,16 +261,59 @@ subtest 'closure ret' => sub {
     $f;
   };
 
-  my $f = $ffi->closure(sub {
-    return Closure::Record::Simple->new( foo => 1, bar => 2, baz => 3 );
-  });
+  subtest 'good' => sub {
 
-  my $r = $cxv_closure_simple_call->call($f);
+    my $f = $ffi->closure(sub {
+      return Closure::Record::Simple->new( foo => 1, bar => 2, baz => 3 );
+    });
 
-  isa_ok $r, 'Closure::Record::Simple';
-  is $r->foo, 1;
-  is $r->bar, 2;
-  is $r->baz, 3;
+    my $r = $cxv_closure_simple_call->call($f);
+
+    isa_ok $r, 'Closure::Record::Simple';
+    is $r->foo, 1;
+    is $r->bar, 2;
+    is $r->baz, 3;
+  };
+
+  subtest 'bad' => sub {
+
+    my $f = $ffi->closure(sub {
+      return undef;
+    });
+
+    local $SIG{__WARN__} = sub {
+      note @_;
+    };
+
+    my $r = $cxv_closure_simple_call->call($f);
+
+    isa_ok $r, 'Closure::Record::Simple';
+    is $r->foo, 0;
+    is $r->bar, 0;
+    is $r->baz, 0;
+
+  };
+
+  subtest 'short' => sub {
+
+    my $f = $ffi->closure(sub {
+      my $r = Closure::Record::Simple->new;
+      $$r = "";
+      return $r;
+    });
+
+    local $SIG{__WARN__} = sub {
+      note @_;
+    };
+
+    my $r = $cxv_closure_simple_call->call($f);
+
+    isa_ok $r, 'Closure::Record::Simple';
+    is $r->foo, 0;
+    is $r->bar, 0;
+    is $r->baz, 0;
+
+  };
 
 };
 

--- a/t/type_record_value.t
+++ b/t/type_record_value.t
@@ -98,7 +98,7 @@ subtest 'is a reference' => sub {
 
 subtest 'closure' => sub {
 
-  { package Closture::Record::RW;
+  { package Closure::Record::RW;
 
     use FFI::Platypus::Record;
 
@@ -116,7 +116,7 @@ subtest 'closure' => sub {
 
   my $ffi = FFI::Platypus->new( lib => [@lib], api => 1 );
 
-  $ffi->type('record(Closture::Record::RW)' => 'cx_struct_rw_t');
+  $ffi->type('record(Closure::Record::RW)' => 'cx_struct_rw_t');
   {
     local $@ = '';
     eval { $ffi->type('(cx_struct_rw_t,int)->void' => 'cxv_closure_t') };
@@ -132,7 +132,7 @@ subtest 'closure' => sub {
   my $cxv_closure_set = $ffi->function(cxv_closure_set => [ 'cxv_closure_t' ] => 'void' );
   my $cxv_closure_call = $ffi->function(cxv_closure_call => [ 'cx_struct_rw_t', 'int' ] => 'void' );
 
-  my $r = Closture::Record::RW->new;
+  my $r = Closure::Record::RW->new;
   $r->one("one");
   $r->two("two");
   $r->three(3);
@@ -148,7 +148,7 @@ subtest 'closure' => sub {
   my $f = $ffi->closure(sub {
     my($r2,$num) = @_;
     note "first closure";
-    isa_ok $r2, 'Closture::Record::RW';
+    isa_ok $r2, 'Closure::Record::RW';
     is($r2->_ffi_record_ro, 1);
     is($r2->one, "one");
     is($r2->two, "two");
@@ -232,7 +232,7 @@ subtest 'closure' => sub {
 
 subtest 'closure ret' => sub {
 
-  { package Closture::Record::Simple;
+  { package Closure::Record::Simple;
 
     use FFI::Platypus::Record;
 
@@ -246,7 +246,7 @@ subtest 'closure ret' => sub {
 
   my $ffi = FFI::Platypus->new( lib => [@lib], api => 1 );
 
-  $ffi->type('record(Closture::Record::Simple)' => 'cx_struct_simple_t');
+  $ffi->type('record(Closure::Record::Simple)' => 'cx_struct_simple_t');
 
   {
     local $@ = '';
@@ -254,11 +254,23 @@ subtest 'closure ret' => sub {
     is "$@", '';
   }
 
-  {
+  my $cxv_closure_simple_call = do {
     local $@ = '';
-    my $cxv_closure_simple_call = eval { $ffi->function( cxv_closure_simple_call => ['cxv_closure_simple_t'] => 'cx_struct_simple_t') };
+    my $f = eval { $ffi->function( cxv_closure_simple_call => ['cxv_closure_simple_t'] => 'cx_struct_simple_t') };
     is "$@", '';
-  }
+    $f;
+  };
+
+  my $f = $ffi->closure(sub {
+    return Closure::Record::Simple->new( foo => 1, bar => 2, baz => 3 );
+  });
+
+  my $r = $cxv_closure_simple_call->call($f);
+
+  isa_ok $r, 'Closure::Record::Simple';
+  is $r->foo, 1;
+  is $r->bar, 2;
+  is $r->baz, 3;
 
 };
 

--- a/xs/TypeParser.xs
+++ b/xs/TypeParser.xs
@@ -233,6 +233,9 @@ create_type_closure(self, abi, return_type, ...)
       case FFI_PL_TYPE_OPAQUE:
         ffi_return_type = &ffi_type_pointer;
         break;
+      case FFI_PL_TYPE_RECORD_VALUE:
+        ffi_return_type = return_type->extra[0].record.ffi_type;
+        break;
       default:
         croak("Only native types are supported as closure return types (%d)", return_type->type_code);
         break;

--- a/xs/closure.c
+++ b/xs/closure.c
@@ -266,6 +266,10 @@ ffi_pl_closure_call(ffi_cif *ffi_cif, void *result, void **arguments, void *user
       case FFI_PL_TYPE_OPAQUE:
         *((void**)result) = SvOK(sv) ? INT2PTR(void*, SvIV(sv)) : NULL;
         break;
+      case FFI_PL_TYPE_RECORD_VALUE:
+        /* TODO: type checking! */
+        memcpy(result, SvPV_nolen(SvRV(sv)), extra->return_type->extra[0].record.size);
+        break;
       default:
         warn("bad type");
         break;

--- a/xs/names.c
+++ b/xs/names.c
@@ -49,7 +49,7 @@ ffi_pl_type_to_libffi_type(ffi_pl_type *type)
     case FFI_PL_TYPE_RECORD:
       return &ffi_type_pointer;
     case FFI_PL_TYPE_RECORD_VALUE:
-      return type->extra[0].record.ffi_type;
+      return type->extra[0].record.meta != NULL ? &type->extra[0].record.meta->ffi_type : NULL;
   }
   switch(type_code & (FFI_PL_SHAPE_MASK))
   {


### PR DESCRIPTION
We can't really return a record pointer because the thing pointed to would be immediately de-allocated and we can't return records with pointers to strings because the strings would be de-allocated, but we can return records by-value otherwise.  If you do really need a string member to your record, you can `strdup` it and store it as an opaque.  Be careful of the allocation though!