### PR TITLE
Use parent instead of base

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,8 @@ my %WriteMakefileArgs = (
     "ExtUtils::MakeMaker" => "7.12",
     "ExtUtils::ParseXS"   => "3.30",
     "IPC::Cmd"            => 0,
-    "JSON::PP"            => 0
+    "JSON::PP"            => 0,
+    "parent"              => 0
   },
   "DISTNAME"         => "FFI-Platypus",
   "LICENSE"          => "perl",
@@ -78,7 +79,8 @@ my %WriteMakefileArgs = (
     "IPC::Cmd"            => 0,
     "JSON::PP"            => 0,
     "List::Util"          => "1.45",
-    "constant"            => "1.32"
+    "constant"            => "1.32",
+    "parent"              => 0
   },
   "TEST_REQUIRES" => {
     "Capture::Tiny" => 0,

--- a/dist.ini
+++ b/dist.ini
@@ -131,7 +131,6 @@ diag_preamble = | };
 ; comes with Perl 5.8.1 or better
 remove = strict
 remove = warnings
-remove = base
 remove = overload
 remove = open
 remove = bytes
@@ -179,6 +178,7 @@ ExtUtils::MakeMaker = 7.12
 IPC::Cmd = 0
 Capture::Tiny = 0
 JSON::PP = 0
+parent = 0
 
 ; 3.30 is actually pretty recent.  If Parse is upgraded
 ; after running `perl Makefile.PL` but before running `make`

--- a/examples/archive.pl
+++ b/examples/archive.pl
@@ -35,7 +35,7 @@ $ffi->custom_type(archive_entry => {
 
 package My::Platypus;
 
-use base qw( FFI::Platypus );
+use parent qw( FFI::Platypus );
 
 sub find_symbol
 {

--- a/examples/bundle-answer/lib/Answer.pm
+++ b/examples/bundle-answer/lib/Answer.pm
@@ -3,7 +3,7 @@ package Answer;
 use strict;
 use warnings;
 use FFI::Platypus 1.00;
-use base qw( Exporter );
+use Exporter qw( import );
 
 our @EXPORT = qw( answer );
 

--- a/inc/My/BuildConfig.pm
+++ b/inc/My/BuildConfig.pm
@@ -3,7 +3,7 @@ package My::BuildConfig;
 use strict;
 use warnings;
 use File::Spec ();
-use base qw( My::ConfigPl );
+use parent qw( My::ConfigPl );
 
 sub dir  { File::Spec->catdir( qw( _mm ))                    }
 sub file { File::Spec->catfile( shift->dir, qw( config.pl )) }

--- a/inc/My/ShareConfig.pm
+++ b/inc/My/ShareConfig.pm
@@ -3,7 +3,7 @@ package My::ShareConfig;
 use strict;
 use warnings;
 use File::Spec ();
-use base qw( My::ConfigPl );
+use parent qw( My::ConfigPl );
 
 sub dir  { File::Spec->catdir( qw( blib lib auto share dist FFI-Platypus )) }
 sub file { File::Spec->catfile( shift->dir, qw( config.pl ))                }

--- a/lib/FFI/Build/File/Base.pm
+++ b/lib/FFI/Build/File/Base.pm
@@ -17,7 +17,7 @@ use overload '""' => sub { $_[0]->path }, bool => sub { 1 }, fallback => 1;
 Create your own file class
 
  package FFI::Build::File::Foo;
- use base qw( FFI::Build::File::Base );
+ use parent qw( FFI::Build::File::Base );
  use constant default_suffix => '.foo';
  use constant default_encoding => ':utf8';
 

--- a/lib/FFI/Build/File/C.pm
+++ b/lib/FFI/Build/File/C.pm
@@ -3,7 +3,7 @@ package FFI::Build::File::C;
 use strict;
 use warnings;
 use 5.008004;
-use base qw( FFI::Build::File::Base );
+use parent qw( FFI::Build::File::Base );
 use constant default_suffix => '.c';
 use constant default_encoding => ':utf8';
 use Capture::Tiny ();

--- a/lib/FFI/Build/File/CXX.pm
+++ b/lib/FFI/Build/File/CXX.pm
@@ -3,7 +3,7 @@ package FFI::Build::File::CXX;
 use strict;
 use warnings;
 use 5.008004;
-use base qw( FFI::Build::File::C );
+use parent qw( FFI::Build::File::C );
 use constant default_suffix => '.cxx';
 use constant default_encoding => ':utf8';
 

--- a/lib/FFI/Build/File/Library.pm
+++ b/lib/FFI/Build/File/Library.pm
@@ -3,7 +3,7 @@ package FFI::Build::File::Library;
 use strict;
 use warnings;
 use 5.008004;
-use base qw( FFI::Build::File::Base );
+use parent qw( FFI::Build::File::Base );
 use constant default_encoding => ':raw';
 
 # ABSTRACT: Class to track object file in FFI::Build

--- a/lib/FFI/Build/File/Object.pm
+++ b/lib/FFI/Build/File/Object.pm
@@ -3,7 +3,7 @@ package FFI::Build::File::Object;
 use strict;
 use warnings;
 use 5.008004;
-use base qw( FFI::Build::File::Base );
+use parent qw( FFI::Build::File::Base );
 use constant default_encoding => ':raw';
 use Carp ();
 

--- a/lib/FFI/Platypus/API.pm
+++ b/lib/FFI/Platypus/API.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.008004;
 use FFI::Platypus;
-use base qw( Exporter );
+use Exporter qw( import );
 
 our @EXPORT = grep /^arguments_/, keys %FFI::Platypus::API::;
 
@@ -14,9 +14,9 @@ our @EXPORT = grep /^arguments_/, keys %FFI::Platypus::API::;
 =head1 SYNOPSIS
 
  package FFI::Platypus::Type::MyCustomType;
- 
+
  use FFI::Platypus::API;
- 
+
  sub ffi_custom_type_api_1
  {
    {

--- a/lib/FFI/Platypus/Buffer.pm
+++ b/lib/FFI/Platypus/Buffer.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.008004;
 use FFI::Platypus;
-use base qw( Exporter );
+use Exporter qw( import );
 
 our @EXPORT = qw( scalar_to_buffer buffer_to_scalar );
 our @EXPORT_OK = qw ( scalar_to_pointer grow set_used_length window );

--- a/lib/FFI/Platypus/Constant.pm
+++ b/lib/FFI/Platypus/Constant.pm
@@ -29,7 +29,7 @@ C<lib/Foo.pm>:
  use strict;
  use warnings;
  use FFI::Platypus 1.00;
- use base qw( Exporter );
+ use Exporter qw( import );
  
  my $ffi = FFI::Platypus->new( api => 1 );
  # sets constatns Foo::FOO and ABC::DEF from C

--- a/lib/FFI/Platypus/DL.pm
+++ b/lib/FFI/Platypus/DL.pm
@@ -3,7 +3,7 @@ package FFI::Platypus::DL;
 use strict;
 use warnings;
 use 5.008004;
-use base qw( Exporter );
+use Exporter qw( import );
 
 require FFI::Platypus;
 our @EXPORT = qw( dlopen dlerror dlsym dlclose );

--- a/lib/FFI/Platypus/Function.pm
+++ b/lib/FFI/Platypus/Function.pm
@@ -64,7 +64,7 @@ use overload '&{}' => sub {
 
 package FFI::Platypus::Function::Function;
 
-use base qw( FFI::Platypus::Function );
+use parent qw( FFI::Platypus::Function );
 
 sub attach
 {
@@ -100,7 +100,7 @@ sub sub_ref
 
 package FFI::Platypus::Function::Wrapper;
 
-use base qw( FFI::Platypus::Function );
+use parent qw( FFI::Platypus::Function );
 
 sub new
 {

--- a/lib/FFI/Platypus/Internal.pm
+++ b/lib/FFI/Platypus/Internal.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.008004;
 use FFI::Platypus;
-use base qw( Exporter );
+use Exporter qw( import );
 
 require FFI::Platypus;
 _init();

--- a/lib/FFI/Platypus/Memory.pm
+++ b/lib/FFI/Platypus/Memory.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.008004;
 use FFI::Platypus;
-use base qw( Exporter );
+use Exporter qw( import );
 
 # ABSTRACT: Memory functions for FFI
 # VERSION

--- a/lib/FFI/Platypus/Record.pm
+++ b/lib/FFI/Platypus/Record.pm
@@ -5,7 +5,7 @@ use warnings;
 use 5.008004;
 use Carp qw( croak );
 use FFI::Platypus;
-use base qw( Exporter );
+use Exporter qw( import );
 use constant 1.32 ();
 
 our @EXPORT = qw( record_layout record_layout_1 );

--- a/lib/FFI/Platypus/Type.pm
+++ b/lib/FFI/Platypus/Type.pm
@@ -915,7 +915,7 @@ constants in your Perl module, like this:
  package Foo;
  
  use FFI::Platypus 1.00;
- use base qw( Exporter );
+ use Exporter qw( import );
  
  our @EXPORT_OK = qw( FOO_STATIC FOO_DYNAMIC FOO_OTHER foo get_foo );
  

--- a/lib/FFI/Platypus/TypeParser/Version0.pm
+++ b/lib/FFI/Platypus/TypeParser/Version0.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.008004;
 use Carp qw( croak );
-use base qw( FFI::Platypus::TypeParser );
+use parent qw( FFI::Platypus::TypeParser );
 
 # ABSTRACT: FFI Type Parser Version Zero
 # VERSION

--- a/lib/FFI/Platypus/TypeParser/Version1.pm
+++ b/lib/FFI/Platypus/TypeParser/Version1.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.008004;
 use Carp qw( croak );
-use base qw( FFI::Platypus::TypeParser );
+use parent qw( FFI::Platypus::TypeParser );
 
 # ABSTRACT: FFI Type Parser Version One
 # VERSION

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -26,6 +26,7 @@ $modules{$_} = $_ for qw(
   Test2::V0
   constant
   forks
+  parent
 );
 
 $post_diag = sub {

--- a/t/ffi_build.t
+++ b/t/ffi_build.t
@@ -30,13 +30,13 @@ subtest 'basic' => sub {
 subtest 'file classes' => sub {
   {
     package FFI::Build::File::Foo1;
-    use base qw( FFI::Build::File::Base );
+    use parent qw( FFI::Build::File::Base );
     $INC{'FFI/Build/File/Foo1.pm'} = __FILE__;
   }
 
   {
     package FFI::Build::File::Foo2;
-    use base qw( FFI::Build::File::Base );
+    use parent qw( FFI::Build::File::Base );
   }
 
   my @list = FFI::Build::_file_classes();

--- a/t/ffi_build_file_base.t
+++ b/t/ffi_build_file_base.t
@@ -4,7 +4,7 @@ use FFI::Build::File::Base;
 {
   package
     FFI::Build::File::Foo;
-  use base qw( FFI::Build::File::Base );
+  use parent qw( FFI::Build::File::Base );
   use constant default_suffix    => '.foo';
   use constant default_encoding  => ':utf8';
 }

--- a/t/lib/Test/Cleanup.pm
+++ b/t/lib/Test/Cleanup.pm
@@ -2,7 +2,7 @@ package Test::Cleanup;
 
 use strict;
 use warnings;
-use base qw( Exporter );
+use Exporter qw( import );
 use File::Path qw( rmtree );
 
 our @EXPORT = qw( cleanup );

--- a/t/lib/Test/Platypus.pm
+++ b/t/lib/Test/Platypus.pm
@@ -3,7 +3,7 @@ package Test::Platypus;
 use strict;
 use warnings;
 use Test2::API qw( context );
-use base qw( Exporter );
+use Exporter qw( import );
 
 our @EXPORT = qw( platypus );
 


### PR DESCRIPTION
The use of `base` is discouraged in favour of `parent`, which has been in core since 5.10. The only exception to this is for modules that use the also-discouraged `fields` pragma, but this is not the case for FFI::Platypus, so we can safely switch.

Please feel free to close this if there is some reason to prefer `base` instead for this distribution.