### PR TITLE
Fix references to struct class in documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ package Unix::TimeStruct {
   });
 }
 
-# now we can actually use our My::UnixTime class
+# now we can actually use our Unix::TimeStruct class
 my $time = Unix::TimeStruct->localtime;
 printf "time is %d:%d:%d %s\n",
   $time->tm_hour,

--- a/examples/time_oo.pl
+++ b/examples/time_oo.pl
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-package My::UnixTime;
+package Unix::TimeStruct;
 
 use FFI::Platypus 1.00;
 use FFI::TinyCC;
@@ -35,7 +35,7 @@ my $tm_size = tcc_eval qq{
   }
 };
 
-# To use My::UnixTime as a record class, we need to
+# To use Unix::TimeStruct as a record class, we need to
 # specify a size for the record, a function called
 # either ffi_record_size or _ffi_record_size should
 # return the size in bytes.  This function has to
@@ -44,9 +44,9 @@ sub _ffi_record_size { $tm_size };
 
 my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(undef);
-# define a record class My::UnixTime and alias it
+# define a record class Unix::TimeStruct and alias it
 # to "tm"
-$ffi->type("record(My::UnixTime)*" => 'tm');
+$ffi->type("record(Unix::TimeStruct)*" => 'tm');
 
 # attach the C localtime function as a constructor
 $ffi->attach( [ localtime => '_new' ] => ['time_t*'] => 'tm' );
@@ -84,6 +84,6 @@ foreach my $attr (qw( hour min sec ))
 
 package main;
 
-# now we can actually use our My::UnixTime class
-my $time = My::UnixTime->new;
+# now we can actually use our Unix::TimeStruct class
+my $time = Unix::TimeStruct->new;
 printf "time is %d:%d:%d\n", $time->get_hour, $time->get_min, $time->get_sec;

--- a/examples/time_record.pl
+++ b/examples/time_record.pl
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-package My::UnixTime;
+package Unix::TimeStruct;
 
 use FFI::Platypus 1.00;
 use FFI::Platypus::Record;
@@ -22,8 +22,8 @@ record_layout_1(qw(
 
 my $ffi = FFI::Platypus->new( api => 1 );
 $ffi->lib(undef);
-# define a record class My::UnixTime and alias it to "tm"
-$ffi->type("record(My::UnixTime)*" => 'tm');
+# define a record class Unix::TimeStruct and alias it to "tm"
+$ffi->type("record(Unix::TimeStruct)*" => 'tm');
 
 # attach the C localtime function as a constructor
 $ffi->attach( localtime => ['time_t*'] => 'tm', sub {
@@ -34,8 +34,8 @@ $ffi->attach( localtime => ['time_t*'] => 'tm', sub {
 
 package main;
 
-# now we can actually use our My::UnixTime class
-my $time = My::UnixTime->localtime;
+# now we can actually use our Unix::TimeStruct class
+my $time = Unix::TimeStruct->localtime;
 printf "time is %d:%d:%d %s\n",
   $time->tm_hour,
   $time->tm_min,

--- a/examples/time_struct.pl
+++ b/examples/time_struct.pl
@@ -41,7 +41,7 @@ package Unix::TimeStruct {
   });
 }
 
-# now we can actually use our My::UnixTime class
+# now we can actually use our Unix::TimeStruct class
 my $time = Unix::TimeStruct->localtime;
 printf "time is %d:%d:%d %s\n",
   $time->tm_hour,


### PR DESCRIPTION
There are a couple of other places in the example scripts where the example packages are named My::UnixTime, but in these examples the referenced package name seems a little out of place.

An alternative to fix this is to choose one consistent name for the example package. If this is your preferred solution, I'll be happy to make that change instead.