### PR TITLE
Allow passing array references in to poiner arguments.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Experimental: with api => 2, you can now pass an array reference to
+    a pointer argument, which is roughly equivalent to an array type with
+    no size, example: sint[] (gh#227, gh#332)
 
 1.44      2021-06-20 06:50:03 -0600
   - Migrate test suite to Test::V0 (gh#327)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ the [lib](#lib) attribute.
 
 - api
 
+    \[version 0.91\]
+
     Sets the API level.  Legal values are
 
     - `0`

--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ the [lib](#lib) attribute.
         All new code should be written with this set to 1!  The Platypus documentation
         assumes this api level is set.
 
+    - `2`
+
+        Enable version 2 API, which is currently experimental.  Using API level 2 prior
+        to Platypus version 2.00 will trigger a (noisy) warning.
+
+        API version 2 is identical to version 1, except:
+
+        - Pointer functions that return `NULL` will return `undef` instead of empty list
+
+            This is a long standing design bug in Platypus.
+
+        - Array references may be passed to pointer argument types
+
+            This replicates the behavior of array argument types with no size.  So the types `sint8*` and `sint8[]`
+            behave identically when an array reference is passed in.  They differ in that, as before, you can
+            pass a scalar reference into type `sint8*`.
+
 - lib
 
     Either a pathname (string) or a list of pathnames (array ref of strings)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ the [lib](#lib) attribute.
 
         - Pointer functions that return `NULL` will return `undef` instead of empty list
 
-            This is a long standing design bug in Platypus.
+            This fixes a long standing design bug in Platypus.
 
         - Array references may be passed to pointer argument types
 

--- a/include/ffi_platypus_call.h
+++ b/include/ffi_platypus_call.h
@@ -452,6 +452,24 @@
                             ((double*)ptr)[n] = SvNV(*av_fetch(av, n, 1));
                           }
                           break;
+#ifdef FFI_PL_PROBE_COMPLEX
+                        case FFI_PL_TYPE_COMPLEX_FLOAT | FFI_PL_SHAPE_POINTER:
+                          Newx(ptr, count, float complex);
+                          for(n=0; n<count; n++)
+                          {
+                            SV *sv = *av_fetch(av, n, 1);
+                            ffi_pl_perl_to_complex_float(sv, &((float*)ptr)[n*2]);
+                          }
+                          break;
+                        case FFI_PL_TYPE_COMPLEX_DOUBLE | FFI_PL_SHAPE_POINTER:
+                          Newx(ptr, count, double complex);
+                          for(n=0; n<count; n++)
+                          {
+                            SV *sv = *av_fetch(av, n, 1);
+                            ffi_pl_perl_to_complex_double(sv, &((double*)ptr)[n*2]);
+                          }
+                          break;
+#endif
                         default:
                           ptr = NULL;
                           warn("argument type not supported (%d)", i);

--- a/include/ffi_platypus_call.h
+++ b/include/ffi_platypus_call.h
@@ -438,6 +438,20 @@
                             ((int64_t*)ptr)[n] = SvIV(*av_fetch(av, n, 1));
                           }
                           break;
+                        case FFI_PL_TYPE_FLOAT | FFI_PL_SHAPE_POINTER:
+                          Newx(ptr, count, float);
+                          for(n=0; n<count; n++)
+                          {
+                            ((float*)ptr)[n] = SvNV(*av_fetch(av, n, 1));
+                          }
+                          break;
+                        case FFI_PL_TYPE_DOUBLE | FFI_PL_SHAPE_POINTER:
+                          Newx(ptr, count, double);
+                          for(n=0; n<count; n++)
+                          {
+                            ((double*)ptr)[n] = SvNV(*av_fetch(av, n, 1));
+                          }
+                          break;
                         default:
                           ptr = NULL;
                           warn("argument type not supported (%d)", i);

--- a/include/ffi_platypus_call.h
+++ b/include/ffi_platypus_call.h
@@ -496,6 +496,28 @@
                           }
                           break;
 #endif
+                        case FFI_PL_TYPE_STRING | FFI_PL_SHAPE_POINTER:
+                          Newx(ptr, count, char *);
+                          for(n=0; n<count; n++)
+                          {
+                            SV *sv = *av_fetch(av, n, 1);
+                            if(SvOK(sv))
+                            {
+                              char *str;
+                              char *pv;
+                              STRLEN len;
+                              pv = SvPV(sv, len);
+                              /* TODO: this should probably be a malloc since it could be arbitrarily large */
+                              Newx_or_alloca(str, len+1, char);
+                              memcpy(str, pv, len+1);
+                              ((char**)ptr)[n] = str;
+                            }
+                            else
+                            {
+                              ((char**)ptr)[n] = NULL;
+                            }
+                          }
+                          break;
                         default:
                           ptr = NULL;
                           warn("argument type not supported (%d)", i);

--- a/include/ffi_platypus_call.h
+++ b/include/ffi_platypus_call.h
@@ -777,68 +777,71 @@
           {
 
 /*
- * ARGUMENT OUT - POINTER TYPES
+ * ARGUMENT OUT - POINTER & ARRAY TYPES
  */
+
             case FFI_PL_SHAPE_POINTER:
+            /*case FFI_PL_SHAPE_ARRAY:*/
               {
                 void *ptr = ffi_pl_arguments_get_pointer(arguments, i);
                 if(ptr != NULL)
                 {
                   arg = perl_arg_index < items ? ST(perl_arg_index) : &PL_sv_undef;
-                  if(SvTYPE(SvRV(arg)) == SVt_PVAV)
+                  SV *arg2 = SvRV(arg);
+                  if(SvTYPE(arg2) == SVt_PVAV)
                   {
                   }
-                  else if(!SvREADONLY(SvRV(arg)))
+                  else if(SvTYPE(arg2) < SVt_PVAV && !SvREADONLY(arg2))
                   {
                     switch(type_code)
                     {
                       case FFI_PL_TYPE_UINT8 | FFI_PL_SHAPE_POINTER:
-                        sv_setuv(SvRV(arg), *((uint8_t*)ptr));
+                        sv_setuv(arg2, *((uint8_t*)ptr));
                         break;
                       case FFI_PL_TYPE_SINT8 | FFI_PL_SHAPE_POINTER:
-                        sv_setiv(SvRV(arg), *((int8_t*)ptr));
+                        sv_setiv(arg2, *((int8_t*)ptr));
                         break;
                       case FFI_PL_TYPE_UINT16 | FFI_PL_SHAPE_POINTER:
-                        sv_setuv(SvRV(arg), *((uint16_t*)ptr));
+                        sv_setuv(arg2, *((uint16_t*)ptr));
                         break;
                       case FFI_PL_TYPE_SINT16 | FFI_PL_SHAPE_POINTER:
-                        sv_setiv(SvRV(arg), *((int16_t*)ptr));
+                        sv_setiv(arg2, *((int16_t*)ptr));
                         break;
                       case FFI_PL_TYPE_UINT32 | FFI_PL_SHAPE_POINTER:
-                        sv_setuv(SvRV(arg), *((uint32_t*)ptr));
+                        sv_setuv(arg2, *((uint32_t*)ptr));
                         break;
                       case FFI_PL_TYPE_SINT32 | FFI_PL_SHAPE_POINTER:
-                        sv_setiv(SvRV(arg), *((int32_t*)ptr));
+                        sv_setiv(arg2, *((int32_t*)ptr));
                         break;
                       case FFI_PL_TYPE_UINT64 | FFI_PL_SHAPE_POINTER:
-                        sv_setu64(SvRV(arg), *((uint64_t*)ptr));
+                        sv_setu64(arg2, *((uint64_t*)ptr));
                         break;
                       case FFI_PL_TYPE_SINT64 | FFI_PL_SHAPE_POINTER:
-                        sv_seti64(SvRV(arg), *((int64_t*)ptr));
+                        sv_seti64(arg2, *((int64_t*)ptr));
                         break;
                       case FFI_PL_TYPE_FLOAT | FFI_PL_SHAPE_POINTER:
-                        sv_setnv(SvRV(arg), *((float*)ptr));
+                        sv_setnv(arg2, *((float*)ptr));
                         break;
                       case FFI_PL_TYPE_OPAQUE | FFI_PL_SHAPE_POINTER:
                         if( *((void**)ptr) == NULL)
-                          sv_setsv(SvRV(arg), &PL_sv_undef);
+                          sv_setsv(arg2, &PL_sv_undef);
                         else
-                          sv_setiv(SvRV(arg), PTR2IV(*((void**)ptr)));
+                          sv_setiv(arg2, PTR2IV(*((void**)ptr)));
                         break;
                       case FFI_PL_TYPE_DOUBLE | FFI_PL_SHAPE_POINTER:
-                        sv_setnv(SvRV(arg), *((double*)ptr));
+                        sv_setnv(arg2, *((double*)ptr));
                         break;
 #ifdef FFI_PL_PROBE_LONGDOUBLE
                       case FFI_PL_TYPE_LONG_DOUBLE | FFI_PL_SHAPE_POINTER:
-                        ffi_pl_long_double_to_perl(SvRV(arg),(long double*)ptr);
+                        ffi_pl_long_double_to_perl(arg2,(long double*)ptr);
                         break;
 #endif
 #ifdef FFI_PL_PROBE_COMPLEX
                       case FFI_PL_TYPE_COMPLEX_FLOAT | FFI_PL_SHAPE_POINTER:
-                        ffi_pl_complex_float_to_perl(SvRV(arg), (float *)ptr);
+                        ffi_pl_complex_float_to_perl(arg2, (float *)ptr);
                         break;
                       case FFI_PL_TYPE_COMPLEX_DOUBLE | FFI_PL_SHAPE_POINTER:
-                        ffi_pl_complex_double_to_perl(SvRV(arg), (double *)ptr);
+                        ffi_pl_complex_double_to_perl(arg2, (double *)ptr);
                         break;
 #endif
                       case FFI_PL_TYPE_STRING | FFI_PL_SHAPE_POINTER:
@@ -846,11 +849,11 @@
                           char **pv = ptr;
                           if(*pv == NULL)
                           {
-                            sv_setsv(SvRV(arg), &PL_sv_undef);
+                            sv_setsv(arg2, &PL_sv_undef);
                           }
                           else
                           {
-                            sv_setpv(SvRV(arg), *pv);
+                            sv_setpv(arg2, *pv);
                           }
                         }
                         break;

--- a/include/ffi_platypus_call.h
+++ b/include/ffi_platypus_call.h
@@ -452,6 +452,14 @@
                             ((double*)ptr)[n] = SvNV(*av_fetch(av, n, 1));
                           }
                           break;
+                        case FFI_PL_TYPE_OPAQUE | FFI_PL_SHAPE_POINTER:
+                          Newx(ptr, count, void*);
+                          for(n=0; n<count; n++)
+                          {
+                            SV *sv = *av_fetch(av, n, 1);
+                            ((void**)ptr)[n] = SvOK(sv) ? INT2PTR(void*, SvIV(sv)) : NULL;
+                          }
+                          break;
 #ifdef FFI_PL_PROBE_LONGDOUBLE
                         case FFI_PL_TYPE_LONG_DOUBLE | FFI_PL_SHAPE_POINTER:
                           /* gh#236: lets hope the compiler is smart enough to opitmize this */

--- a/include/ffi_platypus_call.h
+++ b/include/ffi_platypus_call.h
@@ -452,6 +452,24 @@
                             ((double*)ptr)[n] = SvNV(*av_fetch(av, n, 1));
                           }
                           break;
+#ifdef FFI_PL_PROBE_LONGDOUBLE
+                        case FFI_PL_TYPE_LONG_DOUBLE | FFI_PL_SHAPE_POINTER:
+                          /* gh#236: lets hope the compiler is smart enough to opitmize this */
+                          if(sizeof(long double) >= 16)
+                          {
+                            Newx(ptr, count, long double);
+                          }
+                          else
+                          {
+                            Newx(ptr, count*16, char);
+                          }
+                          for(n=0; n<count; n++)
+                          {
+                            SV *sv = *av_fetch(av, n, 1);
+                            ffi_pl_perl_to_long_double(sv, &((long double*)ptr)[n]);
+                          }
+                          break;
+#endif
 #ifdef FFI_PL_PROBE_COMPLEX
                         case FFI_PL_TYPE_COMPLEX_FLOAT | FFI_PL_SHAPE_POINTER:
                           Newx(ptr, count, float complex);

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -164,6 +164,8 @@ the L<lib|/lib> attribute.
 
 =item api
 
+[version 0.91]
+
 Sets the API level.  Legal values are
 
 =over

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -193,7 +193,7 @@ API version 2 is identical to version 1, except:
 
 =item Pointer functions that return C<NULL> will return C<undef> instead of empty list
 
-This is a long standing design bug in Platypus.
+This fixes a long standing design bug in Platypus.
 
 =item Array references may be passed to pointer argument types
 

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -182,6 +182,27 @@ version 1.00 will trigger a (noisy) warning.
 All new code should be written with this set to 1!  The Platypus documentation
 assumes this api level is set.
 
+=item C<2>
+
+Enable version 2 API, which is currently experimental.  Using API level 2 prior
+to Platypus version 2.00 will trigger a (noisy) warning.
+
+API version 2 is identical to version 1, except:
+
+=over 4
+
+=item Pointer functions that return C<NULL> will return C<undef> instead of empty list
+
+This is a long standing design bug in Platypus.
+
+=item Array references may be passed to pointer argument types
+
+This replicates the behavior of array argument types with no size.  So the types C<sint8*> and C<sint8[]>
+behave identically when an array reference is passed in.  They differ in that, as before, you can
+pass a scalar reference into type C<sint8*>.
+
+=back
+
 =back
 
 =item lib

--- a/maint/run-before_build.pl
+++ b/maint/run-before_build.pl
@@ -32,8 +32,8 @@ foreach my $bits (qw( 16 32 64 ))
     my $new = $orig;
     $new =~ s/8/$bits/;
 
-    open my $in, '<', $orig;
-    open my $out, '>', $new;
+    open my $in, '<', $orig or die "unable to read $orig";
+    open my $out, '>', $new or die "unable to write $new";
 
     if($orig =~ /\.c$/)
     {
@@ -67,13 +67,13 @@ foreach my $bits (qw( 16 32 64 ))
 
 foreach my $type (qw( double ))
 {
-  foreach my $orig (qw( t/ffi/float.c t/type_float.t ))
+  foreach my $orig (qw( t/ffi/float.c t/type_float.t t/type_complex_float.t t/ffi/complex_float.c ))
   {
     my $new = $orig;
     $new =~ s/float/$type/;
 
-    open my $in, '<', $orig;
-    open my $out, '>', $new;
+    open my $in, '<', $orig or die "unable to read $orig $!";
+    open my $out, '>', $new or die "unable to write $new $!";
 
     if($orig =~ /\.c$/)
     {
@@ -97,6 +97,16 @@ foreach my $type (qw( double ))
     while(<$in>)
     {
       s/float/$type/eg;
+      s/SIZEOF_FLOAT_COMPLEX/"SIZEOF_@{[ uc $type ]}_COMPLEX"/eg;
+      if($type eq 'double')
+      {
+        s/crealf/creal/g;
+        s/cimagf/cimag/g;
+      }
+      else
+      {
+        die 'todo';
+      }
       print $out $_;
     }
 

--- a/t/ffi/complex_double.c
+++ b/t/ffi/complex_double.c
@@ -1,3 +1,8 @@
+/*
+ * DO NOT MODIFY THIS FILE.
+ * This file generated from similar file t/ffi/complex_float.c
+ * all instances of "float" have been changed to "double"
+ */
 #include "libtest.h"
 #if SIZEOF_DOUBLE_COMPLEX
 
@@ -24,13 +29,13 @@ complex_double_to_string(double complex f)
 EXTERN double
 complex_double_ptr_get_real(double complex *f)
 {
-  return crealf(*f);
+  return creal(*f);
 }
 
 EXTERN double
 complex_double_ptr_get_imag(double complex *f)
 {
-  return cimagf(*f);
+  return cimag(*f);
 }
 
 EXTERN void

--- a/t/type_complex_double.t
+++ b/t/type_complex_double.t
@@ -1,3 +1,8 @@
+#
+# DO NOT MODIFY THIS FILE.
+# This file generated from similar file t/type_complex_float.t
+# all instances of "float" have been changed to "double"
+#
 use Test2::V0 -no_srand => 1;
 use FFI::Platypus;
 use FFI::Platypus::TypeParser;

--- a/t/type_complex_float.t
+++ b/t/type_complex_float.t
@@ -152,4 +152,3 @@ foreach my $api (0, 1)
 }
 
 done_testing;
-

--- a/t/type_complex_float.t
+++ b/t/type_complex_float.t
@@ -9,7 +9,7 @@ BEGIN {
     unless FFI::Platypus::TypeParser->have_type('complex_float');
 }
 
-foreach my $api (0, 1)
+foreach my $api (0, 1, 2)
 {
 
   subtest "api = $api" => sub {
@@ -20,7 +20,7 @@ foreach my $api (0, 1)
       warn $message;
     };
 
-    my $ffi = FFI::Platypus->new( api => $api );
+    my $ffi = FFI::Platypus->new( api => $api, experimental => ($api >=2 ? $api : undef) );
     $ffi->lib(find_lib lib => 'test', symbol => 'f0', libpath => 't/ffi');
 
     $ffi->attach(['complex_float_get_real' => 'creal'] => ['complex_float'] => 'float');
@@ -106,7 +106,7 @@ foreach my $api (0, 1)
 
       is(complex_ret(1.0,2.0),       [1.0,2.0], 'standard');
       is(complex_ptr_ret(1.0,2.0),  \[1.0,2.0], 'pointer');
-      is([complex_null()],             [],     'null');
+      is([complex_null()],             $api >= 2 ? [undef] : [],     'null');
 
     };
 
@@ -125,9 +125,38 @@ foreach my $api (0, 1)
 
     };
 
+    subtest 'complex array arg' => sub {
+
+      skip_all 'for api >= 2 only' unless $api >= 2;
+
+      my $f = $ffi->function(complex_float_array_get => ['complex_float*','int'] => 'complex_float' );
+
+      my @a = ([0.0,0.0], [1.0,2.0], [3.0,4.0]);
+      my $ret;
+      is( $ret = $f->call(\@a, 0), [0.0,0.0] )
+        or diag Dumper($ret);
+      is( $ret = $f->call(\@a, 1), [1.0,2.0] )
+        or diag Dumper($ret);
+      is( $ret = $f->call(\@a, 2), [3.0,4.0] )
+        or diag Dumper($ret);
+
+    };
+
     subtest 'complex array arg set' => sub {
 
       my $f = $ffi->function(complex_float_array_set => ['complex_float[]','int','float','float'] => 'void' );
+
+      my @a = ([0.0,0.0], [1.0,2.0], [3.0,4.0]);
+      $f->call(\@a, 1, 5.0, 6.0);
+      is(\@a, [[0.0,0.0], [5.0,6.0], [3.0,4.0]]);
+
+    };
+
+    subtest 'complex array arg set' => sub {
+
+      skip_all 'for api >= 2 only' unless $api >= 2;
+
+      my $f = $ffi->function(complex_float_array_set => ['complex_float*','int','float','float'] => 'void' );
 
       my @a = ([0.0,0.0], [1.0,2.0], [3.0,4.0]);
       $f->call(\@a, 1, 5.0, 6.0);

--- a/t/type_double.t
+++ b/t/type_double.t
@@ -36,7 +36,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [double_static_array => 'static_array'] => [] => 'double_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'double_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [double_sum => 'sum3'] => ['double*'] => 'double');
       $ffi->attach( [double_array_inc => 'array_inc2'] => ['double*'] => 'void');
@@ -57,7 +57,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list,scalar @list), 55, 'sum2([1..10],10) = 55';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is sum3(\@list), 55, 'sum([1..10]) = 55';
     }
@@ -67,7 +67,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       array_inc2(\@list);
       is \@list, [3,4,5,6,7,8,9,10,11,12], 'array increment';

--- a/t/type_double.t
+++ b/t/type_double.t
@@ -36,6 +36,12 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [double_static_array => 'static_array'] => [] => 'double_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'double_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [double_sum => 'sum3'] => ['double*'] => 'double');
+      $ffi->attach( [double_array_inc => 'array_inc2'] => ['double*'] => 'void');
+    }
+
     is add(1.5,2.5), 4, 'add(1.5,2.5) = 4';
     is eval { no warnings; add() }, 0.0, 'add() = 0.0';
 
@@ -51,10 +57,21 @@ foreach my $api (0, 1, 2)
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list,scalar @list), 55, 'sum2([1..10],10) = 55';
 
+    if($api == 2)
+    {
+      is sum3(\@list), 55, 'sum([1..10]) = 55';
+    }
+
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc(); };
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+
+    if($api == 2)
+    {
+      array_inc2(\@list);
+      is \@list, [3,4,5,6,7,8,9,10,11,12], 'array increment';
+    }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_float.t
+++ b/t/type_float.t
@@ -31,7 +31,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [float_static_array => 'static_array'] => [] => 'float_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'float_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [float_sum => 'sum3'] => ['float*'] => 'float');
       $ffi->attach( [float_array_inc => 'array_inc2'] => ['float*'] => 'void');
@@ -52,7 +52,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list,scalar @list), 55, 'sum2([1..10],10) = 55';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is sum3(\@list), 55, 'sum([1..10]) = 55';
     }
@@ -62,7 +62,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       array_inc2(\@list);
       is \@list, [3,4,5,6,7,8,9,10,11,12], 'array increment';

--- a/t/type_float.t
+++ b/t/type_float.t
@@ -31,6 +31,12 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [float_static_array => 'static_array'] => [] => 'float_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'float_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [float_sum => 'sum3'] => ['float*'] => 'float');
+      $ffi->attach( [float_array_inc => 'array_inc2'] => ['float*'] => 'void');
+    }
+
     is add(1.5,2.5), 4, 'add(1.5,2.5) = 4';
     is eval { no warnings; add() }, 0.0, 'add() = 0.0';
 
@@ -46,10 +52,21 @@ foreach my $api (0, 1, 2)
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list,scalar @list), 55, 'sum2([1..10],10) = 55';
 
+    if($api == 2)
+    {
+      is sum3(\@list), 55, 'sum([1..10]) = 55';
+    }
+
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc(); };
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+
+    if($api == 2)
+    {
+      array_inc2(\@list);
+      is \@list, [3,4,5,6,7,8,9,10,11,12], 'array increment';
+    }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_longdouble.t
+++ b/t/type_longdouble.t
@@ -29,7 +29,7 @@ subtest 'Math::LongDouble is loaded when needed for return type' => sub {
   }
 };
 
-foreach my $api (0, 1)
+foreach my $api (0, 1, 2)
 {
 
   subtest "api = $api" => sub {
@@ -40,7 +40,7 @@ foreach my $api (0, 1)
       warn $message;
     };
 
-    my $ffi = FFI::Platypus->new( api => $api );
+    my $ffi = FFI::Platypus->new( api => $api, experimental => ($api >=2 ? $api : undef)  );
     $ffi->lib(find_lib lib => 'test', libpath => 't/ffi');
 
     $ffi->type('longdouble*' => 'longdouble_p');
@@ -50,6 +50,7 @@ foreach my $api (0, 1)
     $ffi->attach( longdouble_pointer_test => ['longdouble_p', 'longdouble_p'] => 'int');
     $ffi->attach( longdouble_array_test => ['longdouble_a', 'int'] => 'int');
     $ffi->attach( [longdouble_array_test => 'longdouble_array_test3'] => ['longdouble_a3', 'int'] => 'int');
+    $ffi->attach( [longdouble_array_test => 'longdouble_array_test_ptr'] => ['longdouble*', 'int'] => 'int') if $api >= 2;
     $ffi->attach( longdouble_array_return_test => [] => 'longdouble_a3');
     $ffi->attach( pointer_is_null => ['longdouble_p'] => 'int');
     $ffi->attach( longdouble_pointer_return_test => ['longdouble'] => 'longdouble_p');
@@ -101,6 +102,17 @@ foreach my $api (0, 1)
         my $list = [ map { Math::LongDouble->new($_) } qw( 25.0 25.0 50.0 )];
 
         ok longdouble_array_test($list, 3);
+        note "[", join(',', map { "$_" } @$list), "]";
+        ok $list->[0] == $ld10;
+        ok $list->[1] == $ld20;
+        ok $list->[2] == $ld30;
+      };
+
+      subtest 'array var ptr' => sub {
+        skip_all 'for api = 2 and better only' unless $api >= 2;
+        my $list = [ map { Math::LongDouble->new($_) } qw( 25.0 25.0 50.0 )];
+
+        ok longdouble_array_test_ptr($list, 3);
         note "[", join(',', map { "$_" } @$list), "]";
         ok $list->[0] == $ld10;
         ok $list->[1] == $ld20;

--- a/t/type_sint16.t
+++ b/t/type_sint16.t
@@ -39,6 +39,7 @@ foreach my $api (0, 1, 2)
     if($api == 2)
     {
       $ffi->attach( [sint16_sum => 'sum3'] => ['sint16*'] => 'sint16' );
+      $ffi->attach( [sint16_array_inc => 'array_inc2'] => ['sint16*'] => 'void');
     }
 
     is add(-1,2), 1, 'add(-1,2) = 1';
@@ -65,6 +66,13 @@ foreach my $api (0, 1, 2)
     do { local $SIG{__WARN__} = sub {}; array_inc() };
 
     is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
+
+    if($api == 2)
+    {
+      @list = (-5,-4,-3,-2,-1,0,1,2,3,4);
+      array_inc2(\@list);
+      is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
+    }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_sint16.t
+++ b/t/type_sint16.t
@@ -36,6 +36,11 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [sint16_static_array => 'static_array'] => [] => 'sint16_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'sint16_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [sint16_sum => 'sum3'] => ['sint16*'] => 'sint16' );
+    }
+
     is add(-1,2), 1, 'add(-1,2) = 1';
     is do { no warnings; add() }, 0, 'add() = 0';
 
@@ -50,6 +55,11 @@ foreach my $api (0, 1, 2)
 
     is sum(\@list), -5, 'sum([-5..4]) = -5';
     is sum2(\@list,scalar @list), -5, 'sum([-5..4],10) = -5';
+
+    if($api == 2)
+    {
+      is(sum3(\@list), -5, 'sum([-5..4]) = -5 (passed as pointer)');
+    }
 
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc() };

--- a/t/type_sint16.t
+++ b/t/type_sint16.t
@@ -36,7 +36,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [sint16_static_array => 'static_array'] => [] => 'sint16_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'sint16_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [sint16_sum => 'sum3'] => ['sint16*'] => 'sint16' );
       $ffi->attach( [sint16_array_inc => 'array_inc2'] => ['sint16*'] => 'void');
@@ -57,7 +57,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), -5, 'sum([-5..4]) = -5';
     is sum2(\@list,scalar @list), -5, 'sum([-5..4],10) = -5';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is(sum3(\@list), -5, 'sum([-5..4]) = -5 (passed as pointer)');
     }
@@ -67,7 +67,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       @list = (-5,-4,-3,-2,-1,0,1,2,3,4);
       array_inc2(\@list);

--- a/t/type_sint32.t
+++ b/t/type_sint32.t
@@ -36,6 +36,11 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [sint32_static_array => 'static_array'] => [] => 'sint32_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'sint32_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [sint32_sum => 'sum3'] => ['sint32*'] => 'sint32' );
+    }
+
     is add(-1,2), 1, 'add(-1,2) = 1';
     is do { no warnings; add() }, 0, 'add() = 0';
 
@@ -50,6 +55,11 @@ foreach my $api (0, 1, 2)
 
     is sum(\@list), -5, 'sum([-5..4]) = -5';
     is sum2(\@list,scalar @list), -5, 'sum([-5..4],10) = -5';
+
+    if($api == 2)
+    {
+      is(sum3(\@list), -5, 'sum([-5..4]) = -5 (passed as pointer)');
+    }
 
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc() };

--- a/t/type_sint32.t
+++ b/t/type_sint32.t
@@ -36,7 +36,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [sint32_static_array => 'static_array'] => [] => 'sint32_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'sint32_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [sint32_sum => 'sum3'] => ['sint32*'] => 'sint32' );
       $ffi->attach( [sint32_array_inc => 'array_inc2'] => ['sint32*'] => 'void');
@@ -57,7 +57,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), -5, 'sum([-5..4]) = -5';
     is sum2(\@list,scalar @list), -5, 'sum([-5..4],10) = -5';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is(sum3(\@list), -5, 'sum([-5..4]) = -5 (passed as pointer)');
     }
@@ -67,7 +67,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       @list = (-5,-4,-3,-2,-1,0,1,2,3,4);
       array_inc2(\@list);

--- a/t/type_sint32.t
+++ b/t/type_sint32.t
@@ -39,6 +39,7 @@ foreach my $api (0, 1, 2)
     if($api == 2)
     {
       $ffi->attach( [sint32_sum => 'sum3'] => ['sint32*'] => 'sint32' );
+      $ffi->attach( [sint32_array_inc => 'array_inc2'] => ['sint32*'] => 'void');
     }
 
     is add(-1,2), 1, 'add(-1,2) = 1';
@@ -65,6 +66,13 @@ foreach my $api (0, 1, 2)
     do { local $SIG{__WARN__} = sub {}; array_inc() };
 
     is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
+
+    if($api == 2)
+    {
+      @list = (-5,-4,-3,-2,-1,0,1,2,3,4);
+      array_inc2(\@list);
+      is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
+    }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_sint64.t
+++ b/t/type_sint64.t
@@ -39,6 +39,7 @@ foreach my $api (0, 1, 2)
     if($api == 2)
     {
       $ffi->attach( [sint64_sum => 'sum3'] => ['sint64*'] => 'sint64' );
+      $ffi->attach( [sint64_array_inc => 'array_inc2'] => ['sint64*'] => 'void');
     }
 
     is add(-1,2), 1, 'add(-1,2) = 1';
@@ -65,6 +66,13 @@ foreach my $api (0, 1, 2)
     do { local $SIG{__WARN__} = sub {}; array_inc() };
 
     is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
+
+    if($api == 2)
+    {
+      @list = (-5,-4,-3,-2,-1,0,1,2,3,4);
+      array_inc2(\@list);
+      is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
+    }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_sint64.t
+++ b/t/type_sint64.t
@@ -36,6 +36,11 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [sint64_static_array => 'static_array'] => [] => 'sint64_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'sint64_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [sint64_sum => 'sum3'] => ['sint64*'] => 'sint64' );
+    }
+
     is add(-1,2), 1, 'add(-1,2) = 1';
     is do { no warnings; add() }, 0, 'add() = 0';
 
@@ -50,6 +55,11 @@ foreach my $api (0, 1, 2)
 
     is sum(\@list), -5, 'sum([-5..4]) = -5';
     is sum2(\@list,scalar @list), -5, 'sum([-5..4],10) = -5';
+
+    if($api == 2)
+    {
+      is(sum3(\@list), -5, 'sum([-5..4]) = -5 (passed as pointer)');
+    }
 
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc() };

--- a/t/type_sint64.t
+++ b/t/type_sint64.t
@@ -36,7 +36,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [sint64_static_array => 'static_array'] => [] => 'sint64_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'sint64_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [sint64_sum => 'sum3'] => ['sint64*'] => 'sint64' );
       $ffi->attach( [sint64_array_inc => 'array_inc2'] => ['sint64*'] => 'void');
@@ -57,7 +57,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), -5, 'sum([-5..4]) = -5';
     is sum2(\@list,scalar @list), -5, 'sum([-5..4],10) = -5';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is(sum3(\@list), -5, 'sum([-5..4]) = -5 (passed as pointer)');
     }
@@ -67,7 +67,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       @list = (-5,-4,-3,-2,-1,0,1,2,3,4);
       array_inc2(\@list);

--- a/t/type_sint8.t
+++ b/t/type_sint8.t
@@ -34,6 +34,7 @@ foreach my $api (0, 1, 2)
     if($api == 2)
     {
       $ffi->attach( [sint8_sum => 'sum3'] => ['sint8*'] => 'sint8' );
+      $ffi->attach( [sint8_array_inc => 'array_inc2'] => ['sint8*'] => 'void');
     }
 
     is add(-1,2), 1, 'add(-1,2) = 1';
@@ -60,6 +61,13 @@ foreach my $api (0, 1, 2)
     do { local $SIG{__WARN__} = sub {}; array_inc() };
 
     is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
+
+    if($api == 2)
+    {
+      @list = (-5,-4,-3,-2,-1,0,1,2,3,4);
+      array_inc2(\@list);
+      is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
+    }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_sint8.t
+++ b/t/type_sint8.t
@@ -31,7 +31,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [sint8_static_array => 'static_array'] => [] => 'sint8_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'sint8_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [sint8_sum => 'sum3'] => ['sint8*'] => 'sint8' );
       $ffi->attach( [sint8_array_inc => 'array_inc2'] => ['sint8*'] => 'void');
@@ -52,7 +52,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), -5, 'sum([-5..4]) = -5';
     is sum2(\@list,scalar @list), -5, 'sum([-5..4],10) = -5';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is(sum3(\@list), -5, 'sum([-5..4]) = -5 (passed as pointer)');
     }
@@ -62,7 +62,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [-4,-3,-2,-1,0,1,2,3,4,5], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       @list = (-5,-4,-3,-2,-1,0,1,2,3,4);
       array_inc2(\@list);

--- a/t/type_sint8.t
+++ b/t/type_sint8.t
@@ -31,6 +31,11 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [sint8_static_array => 'static_array'] => [] => 'sint8_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'sint8_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [sint8_sum => 'sum3'] => ['sint8*'] => 'sint8' );
+    }
+
     is add(-1,2), 1, 'add(-1,2) = 1';
     is do { no warnings; add() }, 0, 'add() = 0';
 
@@ -45,6 +50,11 @@ foreach my $api (0, 1, 2)
 
     is sum(\@list), -5, 'sum([-5..4]) = -5';
     is sum2(\@list,scalar @list), -5, 'sum([-5..4],10) = -5';
+
+    if($api == 2)
+    {
+      is(sum3(\@list), -5, 'sum([-5..4]) = -5 (passed as pointer)');
+    }
 
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc() };

--- a/t/type_string.t
+++ b/t/type_string.t
@@ -132,6 +132,23 @@ foreach my $api (0, 1, 2)
       is $get_string_from_array->(\@list, 3), undef, "get_string_from_array(\@list, 3) = undef";
     };
 
+    subtest 'variable length input' => sub {
+
+      skip_all 'test requires api >=2'
+        unless $api >= 2;
+
+      my $get_string_from_array = $ffi->function(get_string_from_array => ['string*','int'] => 'string');
+
+      my @list = ('foo', 'bar', 'baz', undef );
+
+      for(0..2)
+      {
+        is $get_string_from_array->(\@list, $_), $list[$_], "get_string_from_array(\@list, $_) = $list[$_]";
+      }
+
+      is $get_string_from_array->(\@list, 3), undef, "get_string_from_array(\@list, 3) = undef";
+    };
+
     subtest 'fixed length return' => sub {
 
       $ffi->type('string[3]' => 'sa3');

--- a/t/type_uint16.t
+++ b/t/type_uint16.t
@@ -36,7 +36,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [uint16_static_array => 'static_array'] => [] => 'uint16_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'uint16_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [uint16_sum => 'sum3'] => ['uint16*'] => 'uint16' );
       $ffi->attach( [uint16_array_inc => 'array_inc2'] => ['uint16*'] => 'void');
@@ -57,7 +57,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list, scalar @list), 55, 'sum2([1..10],10) = 55';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is(sum3(\@list), 55, 'sum([1..10]) = 55 (passed as pointer)');
     }
@@ -67,7 +67,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       @list = (1,2,3,4,5,6,7,8,9,10);
       array_inc2(\@list);

--- a/t/type_uint16.t
+++ b/t/type_uint16.t
@@ -36,6 +36,11 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [uint16_static_array => 'static_array'] => [] => 'uint16_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'uint16_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [uint16_sum => 'sum3'] => ['uint16*'] => 'uint16' );
+    }
+
     is add(1,2), 3, 'add(1,2) = 3';
     is do { no warnings; add() }, 0, 'add() = 0';
 
@@ -50,6 +55,11 @@ foreach my $api (0, 1, 2)
 
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list, scalar @list), 55, 'sum2([1..10],10) = 55';
+
+    if($api == 2)
+    {
+      is(sum3(\@list), 55, 'sum([1..10]) = 55 (passed as pointer)');
+    }
 
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc() };

--- a/t/type_uint16.t
+++ b/t/type_uint16.t
@@ -39,6 +39,7 @@ foreach my $api (0, 1, 2)
     if($api == 2)
     {
       $ffi->attach( [uint16_sum => 'sum3'] => ['uint16*'] => 'uint16' );
+      $ffi->attach( [uint16_array_inc => 'array_inc2'] => ['uint16*'] => 'void');
     }
 
     is add(1,2), 3, 'add(1,2) = 3';
@@ -65,6 +66,13 @@ foreach my $api (0, 1, 2)
     do { local $SIG{__WARN__} = sub {}; array_inc() };
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+
+    if($api == 2)
+    {
+      @list = (1,2,3,4,5,6,7,8,9,10);
+      array_inc2(\@list);
+      is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+   }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_uint32.t
+++ b/t/type_uint32.t
@@ -36,6 +36,11 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [uint32_static_array => 'static_array'] => [] => 'uint32_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'uint32_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [uint32_sum => 'sum3'] => ['uint32*'] => 'uint32' );
+    }
+
     is add(1,2), 3, 'add(1,2) = 3';
     is do { no warnings; add() }, 0, 'add() = 0';
 
@@ -50,6 +55,11 @@ foreach my $api (0, 1, 2)
 
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list, scalar @list), 55, 'sum2([1..10],10) = 55';
+
+    if($api == 2)
+    {
+      is(sum3(\@list), 55, 'sum([1..10]) = 55 (passed as pointer)');
+    }
 
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc() };

--- a/t/type_uint32.t
+++ b/t/type_uint32.t
@@ -39,6 +39,7 @@ foreach my $api (0, 1, 2)
     if($api == 2)
     {
       $ffi->attach( [uint32_sum => 'sum3'] => ['uint32*'] => 'uint32' );
+      $ffi->attach( [uint32_array_inc => 'array_inc2'] => ['uint32*'] => 'void');
     }
 
     is add(1,2), 3, 'add(1,2) = 3';
@@ -65,6 +66,13 @@ foreach my $api (0, 1, 2)
     do { local $SIG{__WARN__} = sub {}; array_inc() };
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+
+    if($api == 2)
+    {
+      @list = (1,2,3,4,5,6,7,8,9,10);
+      array_inc2(\@list);
+      is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+   }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_uint32.t
+++ b/t/type_uint32.t
@@ -36,7 +36,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [uint32_static_array => 'static_array'] => [] => 'uint32_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'uint32_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [uint32_sum => 'sum3'] => ['uint32*'] => 'uint32' );
       $ffi->attach( [uint32_array_inc => 'array_inc2'] => ['uint32*'] => 'void');
@@ -57,7 +57,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list, scalar @list), 55, 'sum2([1..10],10) = 55';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is(sum3(\@list), 55, 'sum([1..10]) = 55 (passed as pointer)');
     }
@@ -67,7 +67,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       @list = (1,2,3,4,5,6,7,8,9,10);
       array_inc2(\@list);

--- a/t/type_uint64.t
+++ b/t/type_uint64.t
@@ -36,6 +36,11 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [uint64_static_array => 'static_array'] => [] => 'uint64_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'uint64_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [uint64_sum => 'sum3'] => ['uint64*'] => 'uint64' );
+    }
+
     is add(1,2), 3, 'add(1,2) = 3';
     is do { no warnings; add() }, 0, 'add() = 0';
 
@@ -50,6 +55,11 @@ foreach my $api (0, 1, 2)
 
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list, scalar @list), 55, 'sum2([1..10],10) = 55';
+
+    if($api == 2)
+    {
+      is(sum3(\@list), 55, 'sum([1..10]) = 55 (passed as pointer)');
+    }
 
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc() };

--- a/t/type_uint64.t
+++ b/t/type_uint64.t
@@ -36,7 +36,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [uint64_static_array => 'static_array'] => [] => 'uint64_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'uint64_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [uint64_sum => 'sum3'] => ['uint64*'] => 'uint64' );
       $ffi->attach( [uint64_array_inc => 'array_inc2'] => ['uint64*'] => 'void');
@@ -57,7 +57,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list, scalar @list), 55, 'sum2([1..10],10) = 55';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is(sum3(\@list), 55, 'sum([1..10]) = 55 (passed as pointer)');
     }
@@ -67,7 +67,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       @list = (1,2,3,4,5,6,7,8,9,10);
       array_inc2(\@list);

--- a/t/type_uint64.t
+++ b/t/type_uint64.t
@@ -39,6 +39,7 @@ foreach my $api (0, 1, 2)
     if($api == 2)
     {
       $ffi->attach( [uint64_sum => 'sum3'] => ['uint64*'] => 'uint64' );
+      $ffi->attach( [uint64_array_inc => 'array_inc2'] => ['uint64*'] => 'void');
     }
 
     is add(1,2), 3, 'add(1,2) = 3';
@@ -65,6 +66,13 @@ foreach my $api (0, 1, 2)
     do { local $SIG{__WARN__} = sub {}; array_inc() };
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+
+    if($api == 2)
+    {
+      @list = (1,2,3,4,5,6,7,8,9,10);
+      array_inc2(\@list);
+      is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+   }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_uint8.t
+++ b/t/type_uint8.t
@@ -31,6 +31,11 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [uint8_static_array => 'static_array'] => [] => 'uint8_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'uint8_a');
 
+    if($api == 2)
+    {
+      $ffi->attach( [uint8_sum => 'sum3'] => ['uint8*'] => 'uint8' );
+    }
+
     is add(1,2), 3, 'add(1,2) = 3';
     is do { no warnings; add() }, 0, 'add() = 0';
 
@@ -45,6 +50,11 @@ foreach my $api (0, 1, 2)
 
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list, scalar @list), 55, 'sum2([1..10],10) = 55';
+
+    if($api == 2)
+    {
+      is(sum3(\@list), 55, 'sum([1..10]) = 55 (passed as pointer)');
+    }
 
     array_inc(\@list);
     do { local $SIG{__WARN__} = sub {}; array_inc() };

--- a/t/type_uint8.t
+++ b/t/type_uint8.t
@@ -34,6 +34,7 @@ foreach my $api (0, 1, 2)
     if($api == 2)
     {
       $ffi->attach( [uint8_sum => 'sum3'] => ['uint8*'] => 'uint8' );
+      $ffi->attach( [uint8_array_inc => 'array_inc2'] => ['uint8*'] => 'void');
     }
 
     is add(1,2), 3, 'add(1,2) = 3';
@@ -60,6 +61,13 @@ foreach my $api (0, 1, 2)
     do { local $SIG{__WARN__} = sub {}; array_inc() };
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+
+    if($api == 2)
+    {
+      @list = (1,2,3,4,5,6,7,8,9,10);
+      array_inc2(\@list);
+      is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
+   }
 
     is [null()], [$api >= 2 ? (undef) : ()], 'null() == undef';
     is is_null(undef), 1, 'is_null(undef) == 1';

--- a/t/type_uint8.t
+++ b/t/type_uint8.t
@@ -31,7 +31,7 @@ foreach my $api (0, 1, 2)
     $ffi->attach( [uint8_static_array => 'static_array'] => [] => 'uint8_a');
     $ffi->attach( [pointer_null => 'null2'] => [] => 'uint8_a');
 
-    if($api == 2)
+    if($api >= 2)
     {
       $ffi->attach( [uint8_sum => 'sum3'] => ['uint8*'] => 'uint8' );
       $ffi->attach( [uint8_array_inc => 'array_inc2'] => ['uint8*'] => 'void');
@@ -52,7 +52,7 @@ foreach my $api (0, 1, 2)
     is sum(\@list), 55, 'sum([1..10]) = 55';
     is sum2(\@list, scalar @list), 55, 'sum2([1..10],10) = 55';
 
-    if($api == 2)
+    if($api >= 2)
     {
       is(sum3(\@list), 55, 'sum([1..10]) = 55 (passed as pointer)');
     }
@@ -62,7 +62,7 @@ foreach my $api (0, 1, 2)
 
     is \@list, [2,3,4,5,6,7,8,9,10,11], 'array increment';
 
-    if($api == 2)
+    if($api >= 2)
     {
       @list = (1,2,3,4,5,6,7,8,9,10);
       array_inc2(\@list);


### PR DESCRIPTION
This is for #227, and also will make code generation easier.

type support:
 - [x] sint* in
 - [x] sint* out
 - [x] uint* in
 - [x] uint* out
 - [x] float, double in
 - [x] float, double out
 - [x] complex in
 - [x] complex out
 - [x] long double in
 - [x] long double out
 - [x] opaque in
 - [x] opaque out
 - [x] string in
 - [x] string out