### PR TITLE
Test2 treats forks as threads, so we need to add our workaround for that too.

### DIFF
--- a/t/forks.t
+++ b/t/forks.t
@@ -31,6 +31,8 @@ sub otherthread
   $val;
 }
 
+ok 1;
+
 is(threads->create(\&otherthread)->join(), 22, 'works in a thread');
 
 is f0(24), 24, 'works in main thread';


### PR DESCRIPTION
The cpantesters matrix for 1.44 looks quite bad oh dear.