### PR TITLE
t/gh323.t: Skip all tests if variadic functions are not supported

### DIFF
--- a/t/gh323.t
+++ b/t/gh323.t
@@ -2,6 +2,10 @@ use Test2::V0 -no_srand => 1;
 use FFI::Platypus;
 use FFI::Platypus::Memory qw( malloc free );
 
+skip_all 'test requires variadic function support'
+  unless eval { FFI::Platypus->new( lib => [undef] )->function(
+    sprintf => ['opaque', 'string'] => ['float'] ) };
+
 foreach my $api (0,1,2)
 {
 


### PR DESCRIPTION
A new t/gh323.t test exhibits variadic functions (sprintf()). The test
failed on systems which do not support them. (s390x with GCC 11 was
reported).

This patch fixes it by skipping the test if the support is missing.
A similar approach has already been used e.g. in
t/ffi_platypus_function.t.

https://github.com/PerlFFI/FFI-Platypus/issues/342