### PR TITLE
dogfood use of api => 2 internally

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Internal refactor (gh#361)
 
 1.58      2022-06-19 06:19:42 -0600
   - TypeParser version 2 accept string(10) as alias for string(10)* (gh#346, gh#359)

--- a/lib/FFI/Platypus/Constant.pm
+++ b/lib/FFI/Platypus/Constant.pm
@@ -96,7 +96,7 @@ Your Perl code doesn't have to do anything when calling bundle:
 =cut
 
 {
-  my $ffi = FFI::Platypus->new( api => 1 );
+  my $ffi = FFI::Platypus->new( api => 2, experimental => 2 );
   $ffi->bundle;
 
   $ffi->type( 'opaque'                => 'ffi_platypus_constant_t' );

--- a/lib/FFI/Platypus/Memory.pm
+++ b/lib/FFI/Platypus/Memory.pm
@@ -107,7 +107,7 @@ copied in the new string.
 
 our @EXPORT = qw( malloc free calloc realloc memcpy memset strdup strndup strcpy );
 
-my $ffi = FFI::Platypus->new( api => 1 );
+my $ffi = FFI::Platypus->new( api => 2, experimental => 2 );
 $ffi->lib(undef);
 $ffi->bundle;
 sub _ffi { $ffi }

--- a/lib/FFI/Platypus/Record.pm
+++ b/lib/FFI/Platypus/Record.pm
@@ -275,14 +275,14 @@ sub record_layout_1
 {
   if(@_ % 2 == 0)
   {
-    my $ffi = FFI::Platypus->new( api => 1 );
+    my $ffi = FFI::Platypus->new( api => 2, experimental => 2 );
     unshift @_, $ffi;
     goto &record_layout;
   }
   elsif(defined $_[0] && ref($_[0]) eq 'ARRAY')
   {
     my @args = @{ shift @_ };
-    unshift @args, api => 1;
+    unshift @args, api => 2, experimental => 2;
     unshift @_, \@args;
     goto &record_layout;
   }

--- a/lib/FFI/Platypus/Type/StringArray.pm
+++ b/lib/FFI/Platypus/Type/StringArray.pm
@@ -63,7 +63,7 @@ use constant _incantation =>
   $^O eq 'MSWin32' && do { require Config; $Config::Config{archname} =~ /MSWin32-x64/ }
   ? 'Q'
   : 'L!';
-use constant _size_of_pointer => FFI::Platypus->new( api => 1 )->sizeof('opaque');
+use constant _size_of_pointer => FFI::Platypus->new( api => 2, experimental => 2 )->sizeof('opaque');
 use constant _pointer_buffer => "P" . _size_of_pointer;
 
 my @stack;
@@ -147,7 +147,7 @@ sub ffi_custom_type_api_1
       $array_pointer;
     };
 
-    my $pointer_buffer = "P@{[ FFI::Platypus->new( api => 1 )->sizeof('opaque') * $count ]}";
+    my $pointer_buffer = "P@{[ FFI::Platypus->new( api => 2, experimental => 2 )->sizeof('opaque') * $count ]}";
     my $incantation_count = _incantation.$count;
 
     $config->{native_to_perl} = sub {

--- a/lib/FFI/Platypus/Type/StringPointer.pm
+++ b/lib/FFI/Platypus/Type/StringPointer.pm
@@ -57,7 +57,7 @@ use constant _incantation =>
   $^O eq 'MSWin32' && do { require Config; $Config::Config{archname} =~ /MSWin32-x64/ }
   ? 'Q'
   : 'L!';
-use constant _pointer_buffer => "P" . FFI::Platypus->new( api => 1 )->sizeof('opaque');
+use constant _pointer_buffer => "P" . FFI::Platypus->new( api => 2, experimental => 2 )->sizeof('opaque');
 
 my @stack;
 

--- a/lib/FFI/Platypus/Type/WideString.pm
+++ b/lib/FFI/Platypus/Type/WideString.pm
@@ -288,7 +288,7 @@ sub _compute_wide_string_encoding
       unless FFI::Platypus::Memory->can("_$need");
   }
 
-  my $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
+  my $ffi = FFI::Platypus->new( api => 2, experimental => 2, lib => [undef] );
 
   my $size = eval { $ffi->sizeof('wchar_t') };
   die 'no wchar_t' if $@;

--- a/t/ffi_platypus_record.t
+++ b/t/ffi_platypus_record.t
@@ -503,7 +503,7 @@ subtest 'api_1' => sub {
     };
 
     is "$@", '';
-    is( $api, 1 );
+    is( $api, 2 );
   };
 
   subtest 'args' => sub {
@@ -520,7 +520,7 @@ subtest 'api_1' => sub {
     };
 
     is "$@", '';
-    is( $api, 1 );
+    is( $api, 2 );
   };
 
   subtest '$ffi' => sub {


### PR DESCRIPTION
Note:  this is technically a breaking change since the FFI::Platypus::Memory functions will return `undef` for NULL instead of empty list.  In practice I think it will probably fix more than it breaks.