### PR TITLE
alllow undef as argument to closure method

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - The closure method now accepts undef as an argument.  It just returns undef
+    which should be accepted by any function that takes a closure. (gh#376, gh#377)
 
 2.01      2022-08-30 15:37:22 -0600
   - Documentation fixes (gh#373)

--- a/lib/FFI/Platypus.pm
+++ b/lib/FFI/Platypus.pm
@@ -911,6 +911,7 @@ closures, see L<FFI::Platypus::Type#Closures> and L<FFI::Platypus::Closure>.
 sub closure
 {
   my($self, $coderef) = @_;
+  return undef unless defined $coderef;
   croak "not a coderef" unless ref $coderef eq 'CODE';
   require FFI::Platypus::Closure;
   FFI::Platypus::Closure->new($coderef);

--- a/t/ffi_platypus.t
+++ b/t/ffi_platypus.t
@@ -1059,4 +1059,12 @@ subtest 'unitof' => sub {
   );
 };
 
+subtest 'pass undef into closure method should just return undef' => sub {
+
+  my $ret = eval { FFI::Platypus->closure(undef) };
+  is "$@", '', 'no error';
+  is $ret, U(), 'returns undef';
+
+};
+
 done_testing;


### PR DESCRIPTION
This is for #376.  Basically undef is a valid argument to a closure, and passing through an undef makes code a little cleaner, where it is a common pattern to pass NULL into a function that takes a function pointer.