### PR TITLE
Refactor Alien::FFI fallback mode to delete

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Refactor Alien::FFI fallback mode to delete it as a prereq when it is not
+    needed instead of adding it when it is.  This way the CPAN river rating
+    for Alien::FFI more closely reflects reality (gh#391)
 
 2.05      2022-11-15 16:59:05 -0700
   - Documentation improvements (gh#387, gh#388)

--- a/dist.ini
+++ b/dist.ini
@@ -169,7 +169,6 @@ remove = Devel::Hide
 remove = forks
 
 ; optional !!
-remove = Alien::FFI
 remove = Alien::FFI::pkgconfig
 
 ; internal
@@ -197,6 +196,7 @@ ExtUtils::ParseXS = 3.30
 [Prereqs / BuildPrereqs]
 -phase = build
 ExtUtils::CBuilder = 0
+Alien::FFI = 0.20
 
 [Prereqs / TestPrereqs]
 -phase = test

--- a/inc/mymm.pl
+++ b/inc/mymm.pl
@@ -61,6 +61,7 @@ sub myWriteMakefile
     require Alien::Base::Wrapper;
     Alien::Base::Wrapper->import( 'Alien::FFI::Vcpkg', '!export');
     %alien = Alien::Base::Wrapper->mm_args;
+    delete $args{BUILD_REQUIRES}->{'Alien::FFI'};
   }
   else
   {
@@ -76,6 +77,7 @@ sub myWriteMakefile
       require Alien::Base::Wrapper;
       Alien::Base::Wrapper->import( 'Alien::FFI::PkgConfigPP', 'Alien::psapi', '!export' );
       %alien = Alien::Base::Wrapper->mm_args;
+      delete $args{BUILD_REQUIRES}->{'Alien::FFI'};
     }
     elsif($alien_install_type_unset && $^O ne 'MSWin32' && Alien::FFI::pkgconfig->exists)
     {
@@ -84,6 +86,7 @@ sub myWriteMakefile
       require Alien::Base::Wrapper;
       Alien::Base::Wrapper->import( 'Alien::FFI::pkgconfig', 'Alien::psapi', '!export' );
       %alien = Alien::Base::Wrapper->mm_args;
+      delete $args{BUILD_REQUIRES}->{'Alien::FFI'};
     }
     else
     {
@@ -93,7 +96,6 @@ sub myWriteMakefile
         CC => '$(FULLPERL) -Iinc -MAlien::Base::Wrapper=Alien::FFI,Alien::psapi -e cc --',
         LD => '$(FULLPERL) -Iinc -MAlien::Base::Wrapper=Alien::FFI,Alien::psapi -e ld --',
       );
-      $args{BUILD_REQUIRES}->{'Alien::FFI'} = '0.20';
     }
   }
   $alien{INC} = defined $alien{INC} ? "-Iinclude $alien{INC}" : "-Iinclude";


### PR DESCRIPTION
Refactor `Alien::FFI` fallback mode to delete it as a prereq when it is not needed instead of adding it when it is.  This way the CPAN river rating for `Alien::FFI` more closely reflects reality