### PR TITLE
FFI::Probe: fix complex float detection

### DIFF
--- a/lib/FFI/Probe.pm
+++ b/lib/FFI/Probe.pm
@@ -454,7 +454,7 @@ sub check_type_float
   return unless $ret;
 
   my $size    = $self->data->{type}->{$type}->{size};
-  my $complex = !!$type =~ /complex/;
+  my $complex = !!($type =~ /complex/);
 
   if($complex) {
     $size /= 2;


### PR DESCRIPTION
`!!$type =~ /complex/` never matches because it is parsed as `(!!$type) =~ /complex/`. Fix the logic by adding parentheses in the right place.