### PR TITLE
Have Closure `sticky` method return instance for chaining w/ constructor

### DIFF
--- a/lib/FFI/Platypus/Closure.pm
+++ b/lib/FFI/Platypus/Closure.pm
@@ -106,9 +106,10 @@ all the reference of the object fall out of scope.
 sub sticky
 {
   my($self) = @_;
-  return if $self->{sticky};
+  return $self if $self->{sticky};
   $self->{sticky} = 1;
   $self->_sticky;
+  return $self;
 }
 
 =head2 unstick


### PR DESCRIPTION
Just a thought ... Could be handy for, e.g.

```perl
sub cb { ... }

my $thing = Some::Struct->new(
    callback => $ffi->cast( '(int)->void' => 'opaque', $ffi->closure( \&cb )->sticky ),
    ...
);
```